### PR TITLE
Allow to return pdf as binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ browser.screenshot(full: true, quality: 60) # "iVBORw0KGgoAAAANSUhEUgAABAAAAAMAC
 Saves PDF on a disk or returns it as base64.
 
 * options `Hash`
-  * :path `String` to save a screenshot on the disk. If passed `:encoding` is
-    set to `:binary` automatically
+  * :path `String` to save a pdf on the disk. `:encoding` will be set to
+    `:binary` automatically
   * :encoding `Symbol` `:base64` | `:binary` you can set it to return pdf as
     Base64
   * :landscape `Boolean` paper orientation. Defaults to false.

--- a/lib/ferrum/page/screenshot.rb
+++ b/lib/ferrum/page/screenshot.rb
@@ -30,10 +30,6 @@ module Ferrum
         encoding = encoding.to_sym
         encoding = :binary if path
 
-        if encoding == :binary && !path
-          raise "You have to provide `:path` for `:binary` encoding"
-        end
-
         [path, encoding]
       end
 


### PR DESCRIPTION
It is usefull when you want to store it to s3 or returning it in a request.

In reply to a request

```ruby
pdf_base64 = browser.pdf
pdf_binary = Base64.decode64(pdf_base64)
browser.quit

send_data pdf_binary, filename: "myfile.pdf", type: "application/pdf", disposition: "attachment"
```

OR

ActiveStorage S3

```ruby
pdf_base64 = browser.pdf
pdf_binary = Base64.decode64(pdf_base64)
browser.quit

invoice.pdf.attach(
  io: pdf_binary,
  filename: filename,
  content_type: "application/pdf",
)
```