### PR TITLE
Add Xvfb support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require "bundler/setup"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "./lib/rake/kill_browsers"
 
 RSpec::Core::RakeTask.new("test")
 

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -6,6 +6,8 @@ require "ferrum/page"
 require "ferrum/contexts"
 require "ferrum/browser/process"
 require "ferrum/browser/client"
+require "ferrum/browser/environment"
+require "ferrum/xvfb/process"
 
 module Ferrum
   class Browser

--- a/lib/ferrum/browser/environment.rb
+++ b/lib/ferrum/browser/environment.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Ferrum
+  class Browser
+    class Environment
+      attr_reader :process_options, :xvfb
+      def initialize(process_options)
+        @process_options = process_options
+      end
+
+      def to_h
+        if xvfb?
+          xvfb_env
+        else
+          default_env
+        end
+      end
+
+      def cleanup!
+        close_xvfb! if xvfb && xvfb.started?
+      end
+
+      private
+
+        def default_env
+          {}
+        end
+
+        def xvfb_env
+          manage_xvfb!
+          { "DISPLAY" => xvfb.display_env_variable }
+        end
+
+        def xvfb?
+          process_options[:headless] == :xvfb
+        end
+
+        def manage_xvfb!
+          @xvfb = Ferrum::Xvfb::Process.new(process_options).start!
+
+          ObjectSpace.define_finalizer(self, xvfb.clean_up_proc)
+        end
+
+        def close_xvfb!
+          xvfb.clean_up_proc.call
+          ObjectSpace.undefine_finalizer(self)
+        end
+    end
+  end
+end

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -63,7 +63,7 @@ module Ferrum
           return
         end
 
-        @environment = Ferrum::Browser::Environment.new(options)
+        @environment = Environment.new(options)
         @logger = options[:logger]
         @process_timeout = options.fetch(:process_timeout, PROCESS_TIMEOUT)
 

--- a/lib/ferrum/xvfb/process.rb
+++ b/lib/ferrum/xvfb/process.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Ferrum
+  module Xvfb
+    class Process
+      attr_reader :process_options
+      def initialize(process_options)
+        @process_options = process_options
+        check_binary!
+      end
+
+      def start!
+        start_process!
+        self
+      end
+
+      def check_binary!
+        raise "Xvfb not found, please try to install it with: sudo apt-get install -y xvfb" if
+            binary_path.empty?
+      end
+
+      def display_env_variable
+        ":#{display_id}"
+      end
+
+      def display_id
+        @display_id ||= (Time.now.to_f * 1000).to_i % 100_000_000
+      end
+
+      def clean_up_proc
+        Proc.new do
+          stop_process! if started?
+        end
+      end
+
+      def start_xvfb_cmd
+        binary_path + " :#{display_id}  -screen 0 #{screen_size}"
+      end
+
+      def screen_size
+        return "1024x768x24" if process_options[:window_size].nil?
+
+        process_options[:window_size].join("x") + "x24"
+      end
+
+      def binary_path
+        @binary_path ||= execute("which Xvfb")
+      end
+
+      def start_process!
+        return if started?
+        @xvfb_pid = ::Process.spawn(start_xvfb_cmd)
+        ::Process.detach(@xvfb_pid)
+        @started = true
+      end
+
+      def stop_process!
+        ::Process.kill('TERM', @xvfb_pid) rescue Errno::ESRCH
+        @started = false
+        sleep 0.1 # is needed, process not ending this fast
+      end
+
+      def execute(cmd)
+        `#{cmd}`.strip
+      end
+
+      def started?
+        @started
+      end
+
+      def alive?
+        return false unless started?
+        process_alive?
+      end
+
+      def process_alive?
+        begin
+          ::Process::kill(0, @xvfb_pid) == 1
+        rescue Errno::ESRCH
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/rake/kill_browsers.rb
+++ b/lib/rake/kill_browsers.rb
@@ -1,0 +1,26 @@
+require "ferrum"
+
+def kill_browsers
+  processes = []
+  running = `ps aux`.split("\n")
+  Ferrum::Browser::Chrome::LINUX_BIN_PATH.each do |binary_name|
+    reg = /#{binary_name}/
+    running.each do |line|
+      processes << line if line.match(reg)
+    end
+  end
+
+  processes.map! { |l| l.split(" ")[1] }
+
+  processes.each { |pid| `kill -9 #{pid} || true` }
+end
+
+desc "kill all instances of chrome"
+task :kill_browsers do
+  print "this will kill all google chrome instances, are you sure? y/n\n"
+
+  next unless STDIN.gets.chomp.chomp.match(/y/i)
+
+  kill_browsers
+  kill_browsers
+end

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -315,6 +315,18 @@ module Ferrum
       end
     end
 
+    it "allows the driver to run tests headless configured to xvfb" do
+      with_xvfb_browser do |url|
+        begin
+          browser = Browser.new(url: url)
+          browser.goto(base_url)
+          expect(browser.body).to include("Hello world!")
+        ensure
+          browser&.quit
+        end
+      end
+    end
+
     it "allows the driver to run tests on external process" do
       with_external_browser do |url|
         begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,20 @@ RSpec.shared_context "Global helpers" do
       process.stop
     end
   end
+
+  def with_xvfb_browser(host: "127.0.0.1", port: 32001)
+    opts = { host: host, port: port, window_size: [1400, 1400], headless: :xvfb }
+    process = Ferrum::Browser::Process.new(opts)
+    begin
+      process.start
+      expect(process.environment.xvfb).to be_process_alive
+      yield "http://#{host}:#{port}"
+    ensure
+      process.stop
+    end
+
+    expect(process.environment.xvfb).not_to be_process_alive
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/xvfb_spec.rb
+++ b/spec/xvfb_spec.rb
@@ -1,0 +1,30 @@
+module Ferrum::Xvfb
+  describe Process do
+    let(:default_options) { { window_size: [1024, 768 ] } }
+    let(:options) { default_options }
+    subject { described_class.new(options).start! }
+
+    after do
+      subject.clean_up_proc.call
+      expect(subject).not_to be_alive
+      expect(subject).not_to be_process_alive
+    end
+
+    it "starts xvfb" do
+      subject
+
+      expect(subject).to be_alive
+    end
+
+    context "no window size supplied" do
+      let(:default_options) { {} }
+
+      it "starts xvfb" do
+        subject
+
+        expect(subject.screen_size).to eq "1024x768x24"
+        expect(subject).to be_alive
+      end
+    end
+  end
+end


### PR DESCRIPTION
I found using Xvfb useful, some sites detect chrome headless.

With this, there is no need for the gem user to manage Xvfb himself. the `DISPLAY` number is generated using the current time in nanoseconds % 100.000.000 so it's a very low chance of colliding