### PR TITLE
Fix main_frame for target _blank links

### DIFF
--- a/lib/ferrum/page/frames.rb
+++ b/lib/ferrum/page/frames.rb
@@ -75,8 +75,11 @@ module Ferrum
           frame_id = params.dig("context", "auxData", "frameId")
 
           unless @main_frame.id
-            @main_frame.id = frame_id
-            @frames[frame_id] = @main_frame
+            root_frame = command('Page.getFrameTree').dig('frameTree', 'frame', 'id')
+            if frame_id == root_frame
+              @main_frame.id = frame_id
+              @frames[frame_id] = @main_frame
+            end
           end
 
           frame = @frames[frame_id] || Frame.new(frame_id, self)

--- a/spec/frame_spec.rb
+++ b/spec/frame_spec.rb
@@ -27,6 +27,14 @@ module Ferrum
         expect(frame.url).to end_with("/ferrum/get_cookie")
       end
 
+      it 'finds main frame properly' do
+        browser.goto("/ferrum/popup_frames")
+        browser.at_xpath("//a[text()='pop up']").click
+        expect(browser.pages.size).to eq(2)
+        opened_page = browser.pages.last
+        expect(opened_page.main_frame.url).to end_with("/frames")
+      end
+
       it "waits for the frame to load" do
         browser.goto
         browser.execute <<-JS

--- a/spec/support/views/popup_frames.erb
+++ b/spec/support/views/popup_frames.erb
@@ -1,0 +1,1 @@
+<a href="frames" target="_blank">pop up</a>


### PR DESCRIPTION
When opening a target _blank link to a page with multiple iframes
the main_frame tracking code got it wrong and picked one of the
iframes as the main_frame. In this case Runtime.executionContextCreated
gets tricked last for the root frame.

For this fix I took the must straightforward route to fixing the problem. However, what is the reason  that Ferrum is doing all this complex tracking of frames when it could just ask Chrome using the API Page.getFrameTree?