### PR TITLE
Relax addressable version

### DIFF
--- a/ferrum.gemspec
+++ b/ferrum.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "websocket-driver", ">= 0.6", "< 0.8"
   s.add_runtime_dependency "cliver",           "~> 0.3"
   s.add_runtime_dependency "concurrent-ruby",  "~> 1.1"
-  s.add_runtime_dependency "addressable",      "~> 2.6"
+  s.add_runtime_dependency "addressable",      "~> 2.5"
 
   s.add_development_dependency "rake",         "~> 12.3"
   s.add_development_dependency "rspec",        "~> 3.8"


### PR DESCRIPTION
# Description

I'm thinking about using `ferrum` in my application but due to some other dependencies, I'm not able due to what `addressable` version is specified in `ferrum`. I checked the [addressable changelog](https://github.com/sporkmonger/addressable/blob/master/CHANGELOG.md#addressable-250) and it seems that there weren't that many changes between addressable 2.5 and addresssable 2.6 so I think we could relax this version a little bit.