### PR TITLE
Fix Ferrum::Browser::Subscriber thread safety

### DIFF
--- a/lib/ferrum/browser/subscriber.rb
+++ b/lib/ferrum/browser/subscriber.rb
@@ -13,7 +13,7 @@ module Ferrum
 
       def initialize
         super
-        @on = Hash.new { |h, k| h[k] = [] }
+        @on = Concurrent::Hash.new { |h, k| h[k] = Concurrent::Array.new }
       end
 
       def on(event, &block)


### PR DESCRIPTION
The on method is called without going through async so all
the data structures need to be thread safe.

https://ruby-concurrency.github.io/concurrent-ruby/1.1.6/Concurrent/Async.html

Changing the call sites would be more in line with Async
documentation but that would be a change in behavior.