### PR TITLE
use strict_encode64 when encoding intercepted_request body

### DIFF
--- a/lib/ferrum/network/intercepted_request.rb
+++ b/lib/ferrum/network/intercepted_request.rb
@@ -39,7 +39,7 @@ module Ferrum
           requestId: request_id,
           responseHeaders: header_array(headers),
         })
-        options = options.merge(body: Base64.encode64(options.fetch(:body, "")).strip) if has_body
+        options = options.merge(body: Base64.strict_encode64(options.fetch(:body, ""))) if has_body
 
         @status = :responded
         @page.command("Fetch.fulfillRequest", **options)

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -309,7 +309,7 @@ module Ferrum
       it "supports custom responses" do
         browser.network.intercept
         browser.on(:request) do |request|
-          request.respond(body: "<h1>content</h1>")
+          request.respond(body: "<h1>custom content that is more than 45 characters</h1>")
         end
 
         browser.goto("/ferrum/non_existing")


### PR DESCRIPTION
### Bug Description
Request interceptors that respond with a custom response body that is greater than 45 characters in length causes a `Ferrum::StatusError`

### Steps to Reproduce
Register request interceptor that responds with a response body that is greater than 45 characters in length.

```ruby
browser.network.intercept
browser.on(:request) do |request|
   if request.match?(/bug-test/)
     request.respond(body: "<h1>custom content that is more than 45 characters</h1>")
   else
     request.continue
   end
 end
```

### Expected Result

Requests matching "bug-test" should respond with `<h1>custom content that is more than 45 characters</h1>`

### Actual Result
```ruby
Ferrum::StatusError:
       Request to #{URL} reached server, but there are still pending connections: /bug-test
```

### Additional Context

The result of `Base64.encode64('<h1>custom content that is more than 45 characters</h1>')` is the following:

PGgxPmN1c3RvbSBjb250ZW50IHRoYXQgbW9yZSB0aGFuIDQ1IGNoYXJhY3Rl\ncnM8L2gxPg==\n

The 60th character in the result above is a newline character. Since this specific newline character does not occur at the end of the base64 encoded string it is not removed when `.strip` is called.

When `@page.command("Fetch.fulfillRequest", **options)` is called with the base64 encoded string above the data returned contains the following error message due to the newline character:

```json
{
  "error": { 
      "code": -32602,
      "message": "Invalid parameters",
      "data": "body: base64 decoding error"
    }
}
```

According to the [ruby documentation](https://ruby-doc.org/stdlib-2.5.3/libdoc/base64/rdoc/Base64.html#method-i-encode64), line feeds are added to every 60 encoded characters when using `encode64`. No line feeds are added when using `strict_encode64`.