### PR TITLE
Include process output in ProcessTimeoutError

### DIFF
--- a/lib/ferrum.rb
+++ b/lib/ferrum.rb
@@ -37,7 +37,10 @@ module Ferrum
   end
 
   class ProcessTimeoutError < Error
-    def initialize(timeout)
+    attr_reader :output
+
+    def initialize(timeout, output)
+      @output = output
       super("Browser did not produce websocket url within #{timeout} seconds")
     end
   end

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -144,7 +144,7 @@ module Ferrum
 
         unless ws_url
           @logger.puts(output) if @logger
-          raise ProcessTimeoutError.new(timeout)
+          raise ProcessTimeoutError.new(timeout, output)
         end
       end
 

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -64,6 +64,16 @@ module Ferrum
       )
     end
 
+    it "includes the process output in the error" do
+      path = "#{PROJECT_ROOT}/spec/support/broken_chrome"
+
+      expect {
+        Browser.new(browser_path: path)
+      }.to raise_error(Ferrum::ProcessTimeoutError) do |ex|
+        expect(ex.output).to include "Broken Chrome error message"
+      end
+    end
+
     it "raises an error and restarts the client if the client dies while executing a command" do
       expect { browser.crash }.to raise_error(Ferrum::DeadBrowserError)
       browser.goto

--- a/spec/support/broken_chrome
+++ b/spec/support/broken_chrome
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Broken Chrome error message"
+echo "$0"
+exit 1


### PR DESCRIPTION
Hello,

First off, thanks for this great library and Cuprite too :raised_hands:

I've experienced a similar issue to #78, in my case relating to Chrome permissions in Docker and found it hard to diagnose the root cause. Although the logging mechanism is useful, I would like to propose including the `output` captured on the `ProcessTimeoutError` itself.

This allows the integrator to capture the exception, which personally I find handy for debugging purposes:

```ruby
begin
  # Something with Ferrum
rescue ProcessTimeoutError => ex
  puts ex.output # or binding.pry etc
end
```

Many thanks,
Oli