### PR TITLE
Fix DNS timeout spec on MacOS

### DIFF
--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -263,13 +263,20 @@ module Ferrum
       end
 
       it "has a descriptive message when DNS incorrect" do
-        url = "http://nope:#{port}/"
-        expect {
-          browser.goto(url)
-        }.to raise_error(
-          Ferrum::StatusError,
-          %(Request to #{url} failed to reach server, check DNS and/or server status)
-        )
+        begin
+          url = "http://nope:#{port}/"
+          old_timeout = browser.timeout
+          browser.timeout = 10 # DNS timeouts vary by platform
+
+          expect {
+            browser.goto(url)
+          }.to raise_error(
+            Ferrum::StatusError,
+            %(Request to #{url} failed to reach server, check DNS and/or server status)
+          )
+        ensure
+          browser.timeout = old_timeout
+        end
       end
 
       it "reports open resource requests" do


### PR DESCRIPTION
In contributing #92, I noticed a different spec always fails on my mac (running MacOS Catalina). The failure is:

```
expected Ferrum::StatusError with "Request to http://nope:59961/ failed to reach
server, check DNS and/or server status", got #<Ferrum::StatusError: Request to
http://nope:59961/ reached server, but there are still pending connections:
http://nope:59961/>
```

On MacOS the default DNS timeout appears to be 5 seconds, however the default Ferrum timeout is 2 seconds. This leads to an exception being thrown with pending connections, rather than the anticipated unreachable error.

## Background info

Running `scutil --dns`:

```
DNS configuration

resolver #1
  nameserver[0] : 194.168.4.100
  nameserver[1] : 194.168.8.100
  if_index : 19 (en10)
  flags    : Request A records
  reach    : 0x00000002 (Reachable)

resolver #2
  domain   : local
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300000

resolver #3
  domain   : 254.169.in-addr.arpa
  options  : mdns
  timeout  : 5
  flags    : Request A records
  reach    : 0x00000000 (Not Reachable)
  order    : 300200

<snip>
```