### PR TITLE
Fix temporary user-data-dir not removed after stop

### DIFF
--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -64,12 +64,12 @@ module Ferrum
           return
         end
 
-        @user_data_dir = nil
         @logger = options[:logger]
         @process_timeout = options.fetch(:process_timeout, PROCESS_TIMEOUT)
 
         tmpdir = Dir.mktmpdir
         ObjectSpace.define_finalizer(self, self.class.directory_remover(tmpdir))
+        @user_data_dir = tmpdir
         @command = Command.build(options, tmpdir)
       end
 


### PR DESCRIPTION
When the `Ferrum::Browser::Process` is garbage collected the temporary
`user-data-dir` is correctly removed, but if `#stop` has been called
then this directory is never removed. That's because `#stop` only
removes the directory if `@user_data_dir` is set (and then clears the
finalizer) and the initialization of `@user_data_dir` has been
mistakenly removed in d98d1f919f5516a1cca07b15c106513e912bd44b.

This patch puts back the initialization of this variable and fixes the
problem. This time the initialization is on its own line to make it
clear we want this instance variable to be defined.

(See also #16 for the original problem)