### PR TITLE
Rename temporary user data directory

### DIFF
--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -67,7 +67,7 @@ module Ferrum
         @logger = options[:logger]
         @process_timeout = options.fetch(:process_timeout, PROCESS_TIMEOUT)
 
-        tmpdir = Dir.mktmpdir
+        tmpdir = Dir.mktmpdir("ferrum_user_data_dir_")
         ObjectSpace.define_finalizer(self, self.class.directory_remover(tmpdir))
         @user_data_dir = tmpdir
         @command = Command.build(options, tmpdir)


### PR DESCRIPTION
The default name prefix for the temporary user data dir is `d` which is
not very helpful when trying to figure out where the directory comes
from. The patch makes the directory name more explicit.