### PR TITLE
fix #95: error 'Could not compute content quads'

### DIFF
--- a/lib/ferrum/node.rb
+++ b/lib/ferrum/node.rb
@@ -141,9 +141,20 @@ module Ferrum
       end.map { |q| to_points(q) }.first
 
       get_position(points, x, y, position)
+    rescue Ferrum::BrowserError => e
+      return raise unless e.message&.include?('Could not compute content quads')
+
+      find_position_via_js
     end
 
     private
+
+    def find_position_via_js
+      [
+        evaluate('this.getBoundingClientRect().left + window.pageXOffset + (this.offsetWidth / 2)'), # x
+        evaluate('this.getBoundingClientRect().top + window.pageYOffset + (this.offsetHeight / 2)') # y
+      ]
+    end
 
     def get_content_quads
       quads = page.command("DOM.getContentQuads", nodeId: node_id)["quads"]

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -528,6 +528,14 @@ module Ferrum
       expect(browser.body).to include("Hello world")
     end
 
+    it "does not run into content quads error" do
+      browser.goto("/ferrum/index")
+      Node.any_instance.stub(:get_content_quads)
+                       .and_raise(Ferrum::BrowserError, 'message' => 'Could not compute content quads')
+      browser.at_xpath("//a[text() = 'JS redirect']").click
+      expect(browser.body).to include("Hello world")
+    end
+
     it "returns BR as new line in #text" do
       browser.goto("/ferrum/simple")
       el = browser.at_css("#break")


### PR DESCRIPTION
Hi @route,

sorry that it took so long. :disappointed: 

So the thing is: in _theory_ [`DOM.getContentQuads`](https://github.com/rubycdp/ferrum/blob/6d1612de80128e4dd20a6cd0881c2ce64bc21d1e/lib/ferrum/node.rb#L149) is absolutely the right thing to do. Depending on the used browser, this seem to be unstable.

Thus, if we're running into this unstable state (and only then!) we're going to calculate the position via JS.
This might be slower, but at least it's working flawlessly. And hopefully `getContentQuads` will become more stable and we won't run into this anymore anyway.

I hope it's working for you and others. At least it's working in the projects of my clients.

**PS:** If you're going to merge this: [would you be so kind and add the `hacktoberfest-accepted` label to this PR](https://hacktoberfest.digitalocean.com/hacktoberfest-update)? Thank you in advance!
**PPS:** We should definitely get rid of all the `sleep`s in the specs and migrate to a more stable solution. Maybe this would be related to #81 / #82 (I still don't know why you created another issue for this). :wink: 