### PR TITLE
chores #106: alias `go_to` to `goto` and use `go_to` within ferrum for Ruby consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Navigate to a website and save a screenshot:
 
 ```ruby
 browser = Ferrum::Browser.new
-browser.goto("https://google.com")
+browser.go_to("https://google.com")
 browser.screenshot(path: "google.png")
 browser.quit
 ```
@@ -91,7 +91,7 @@ Interact with a page:
 
 ```ruby
 browser = Ferrum::Browser.new
-browser.goto("https://google.com")
+browser.go_to("https://google.com")
 input = browser.at_xpath("//input[@name='q']")
 input.focus.type("Ruby headless driver for Chrome", :Enter)
 browser.at_css("a > h3").text # => "rubycdp/ferrum: Ruby Chrome/Chromium driver - GitHub"
@@ -102,7 +102,7 @@ Evaluate some JavaScript and get full width/height:
 
 ```ruby
 browser = Ferrum::Browser.new
-browser.goto("https://www.google.com/search?q=Ruby+headless+driver+for+Capybara")
+browser.go_to("https://www.google.com/search?q=Ruby+headless+driver+for+Capybara")
 width, height = browser.evaluate <<~JS
   [document.documentElement.offsetWidth,
    document.documentElement.offsetHeight]
@@ -116,7 +116,7 @@ Do any mouse movements you like:
 ```ruby
 # Trace a 100x100 square
 browser = Ferrum::Browser.new
-browser.goto("https://google.com")
+browser.go_to("https://google.com")
 browser.mouse
   .move(x: 0, y: 0)
   .down
@@ -194,7 +194,7 @@ Navigate page to.
   configuring driver.
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 ```
 
 #### back
@@ -202,7 +202,7 @@ browser.goto("https://github.com/")
 Navigate to the previous page in history.
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.at_xpath("//a").click
 browser.back
 ```
@@ -212,7 +212,7 @@ browser.back
 Navigate to the next page in history.
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.at_xpath("//a").click
 browser.back
 browser.forward
@@ -223,7 +223,7 @@ browser.forward
 Reload current page.
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.refresh
 ```
 
@@ -232,7 +232,7 @@ browser.refresh
 Stop all navigations and loading pending resources on the page
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.stop
 ```
 
@@ -249,7 +249,7 @@ provided node.
     * :within `Node` | `nil`
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.at_css("a[aria-label='Issues you created']") # => Node
 ```
 
@@ -264,7 +264,7 @@ document or provided node.
   * :within `Node` | `nil`
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.css("a[aria-label='Issues you created']") # => [Node]
 ```
 
@@ -277,7 +277,7 @@ Find node by xpath.
   * :within `Node` | `nil`
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.at_xpath("//a[@aria-label='Issues you created']") # => Node
 ```
 
@@ -290,7 +290,7 @@ Find nodes by xpath.
   * :within `Node` | `nil`
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.xpath("//a[@aria-label='Issues you created']") # => [Node]
 ```
 
@@ -299,7 +299,7 @@ browser.xpath("//a[@aria-label='Issues you created']") # => [Node]
 Returns current top window location href.
 
 ```ruby
-browser.goto("https://google.com/")
+browser.go_to("https://google.com/")
 browser.current_url # => "https://www.google.com/"
 ```
 
@@ -308,7 +308,7 @@ browser.current_url # => "https://www.google.com/"
 Returns current top window title
 
 ```ruby
-browser.goto("https://google.com/")
+browser.go_to("https://google.com/")
 browser.current_title # => "Google"
 ```
 
@@ -317,7 +317,7 @@ browser.current_title # => "Google"
 Returns current page's html.
 
 ```ruby
-browser.goto("https://google.com/")
+browser.go_to("https://google.com/")
 browser.body # => '<html itemscope="" itemtype="http://schema.org/WebPage" lang="ru"><head>...
 ```
 
@@ -340,7 +340,7 @@ Saves screenshot on a disk or returns it as base64.
   * :scale `Float` zoom in/out
 
 ```ruby
-browser.goto("https://google.com/")
+browser.go_to("https://google.com/")
 # Save on the disk in PNG
 browser.screenshot(path: "google.png") # => 134660
 # Save on the disk in JPG
@@ -367,7 +367,7 @@ Saves PDF on a disk or returns it as base64.
   * See other [native options](https://chromedevtools.github.io/devtools-protocol/tot/Page#method-printToPDF) you can pass
 
 ```ruby
-browser.goto("https://google.com/")
+browser.go_to("https://google.com/")
 # Save to disk as a PDF
 browser.pdf(path: "google.pdf", paper_width: 1.0, paper_height: 1.0) # => 14983
 ```
@@ -383,7 +383,7 @@ Returns all information about network traffic as `Network::Exchange` instance
 which in general is a wrapper around `request`, `response` and `error`.
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.network.traffic # => [#<Ferrum::Network::Exchange, ...]
 ```
 
@@ -392,7 +392,7 @@ browser.network.traffic # => [#<Ferrum::Network::Exchange, ...]
 Page request of the main frame.
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.network.request # => #<Ferrum::Network::Request...
 ```
 
@@ -401,7 +401,7 @@ browser.network.request # => #<Ferrum::Network::Request...
 Page response of the main frame.
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.network.response # => #<Ferrum::Network::Response...
 ```
 
@@ -411,7 +411,7 @@ Contains the status code of the main page response (e.g., 200 for a
 success). This is just a shortcut for `response.status`.
 
 ```ruby
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 browser.network.status # => 200
 ```
 
@@ -428,7 +428,7 @@ Waits for network idle or raises `Ferrum::TimeoutError` error
     by default
 
 ```ruby
-browser.goto("https://example.com/")
+browser.go_to("https://example.com/")
 browser.at_xpath("//a[text() = 'No UI changes button']").click
 browser.network.wait_for_idle
 ```
@@ -441,7 +441,7 @@ Clear browser's cache or collected traffic.
 
 ```ruby
 traffic = browser.network.traffic # => []
-browser.goto("https://github.com/")
+browser.go_to("https://github.com/")
 traffic.size # => 51
 browser.network.clear(:traffic)
 traffic.size # => 0
@@ -469,7 +469,7 @@ browser.on(:request) do |request|
     request.continue
   end
 end
-browser.goto("https://google.com")
+browser.go_to("https://google.com")
 ```
 
 #### authorize(\*\*options)
@@ -483,7 +483,7 @@ If site uses authorization you can provide credentials using this method.
 
 ```ruby
 browser.network.authorize(user: "login", password: "pass")
-browser.goto("http://example.com/authenticated")
+browser.go_to("http://example.com/authenticated")
 puts browser.network.status # => 200
 puts browser.body # => Welcome, authenticated client
 ```
@@ -503,7 +503,7 @@ Scroll page to a given x, y
   displayed in the upper left
 
 ```ruby
-browser.goto("https://www.google.com/search?q=Ruby+headless+driver+for+Capybara")
+browser.go_to("https://www.google.com/search?q=Ruby+headless+driver+for+Capybara")
 browser.mouse.scroll_to(0, 400)
 ```
 
@@ -729,7 +729,7 @@ browser.add_style_tag(content: "h1 { font-size: 40px; }") # => true
 
 ```ruby
 browser.bypass_csp # => true
-browser.goto("https://github.com/ruby-concurrency/concurrent-ruby/blob/master/docs-source/promises.in.md")
+browser.go_to("https://github.com/ruby-concurrency/concurrent-ruby/blob/master/docs-source/promises.in.md")
 browser.refresh
 browser.add_script_tag(content: "window.__injected = 42")
 browser.evaluate("window.__injected") # => 42
@@ -743,7 +743,7 @@ browser.evaluate("window.__injected") # => 42
 Returns all the frames current page have.
 
 ```ruby
-browser.goto("https://www.w3schools.com/tags/tag_frame.asp")
+browser.go_to("https://www.w3schools.com/tags/tag_frame.asp")
 browser.frames # =>
 # [
 #   #<Ferrum::Frame @id="C6D104CE454A025FBCF22B98DE612B12" @parent_id=nil @name=nil @state=:stopped_loading @execution_id=1>,
@@ -802,7 +802,7 @@ One of the states frame's in:
 Returns current frame's location href.
 
 ```ruby
-browser.goto("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe")
+browser.go_to("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe")
 frame = browser.frames[1]
 frame.url # => https://interactive-examples.mdn.mozilla.net/pages/tabbed/iframe.html
 ```
@@ -812,7 +812,7 @@ frame.url # => https://interactive-examples.mdn.mozilla.net/pages/tabbed/iframe.
 Returns current frame's title.
 
 ```ruby
-browser.goto("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe")
+browser.go_to("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe")
 frame = browser.frames[1]
 frame.title # => HTML Demo: <iframe>
 ```
@@ -822,7 +822,7 @@ frame.title # => HTML Demo: <iframe>
 If current frame is the main frame of the page (top of the tree).
 
 ```ruby
-browser.goto("https://www.w3schools.com/tags/tag_frame.asp")
+browser.go_to("https://www.w3schools.com/tags/tag_frame.asp")
 frame = browser.frame_by(id: "C09C4E4404314AAEAE85928EAC109A93")
 frame.main? # => false
 ```
@@ -832,7 +832,7 @@ frame.main? # => false
 Returns current frame's top window location href.
 
 ```ruby
-browser.goto("https://www.w3schools.com/tags/tag_frame.asp")
+browser.go_to("https://www.w3schools.com/tags/tag_frame.asp")
 frame = browser.frame_by(id: "C09C4E4404314AAEAE85928EAC109A93")
 frame.current_url # => "https://www.w3schools.com/tags/tag_frame.asp"
 ```
@@ -842,7 +842,7 @@ frame.current_url # => "https://www.w3schools.com/tags/tag_frame.asp"
 Returns current frame's top window title.
 
 ```ruby
-browser.goto("https://www.w3schools.com/tags/tag_frame.asp")
+browser.go_to("https://www.w3schools.com/tags/tag_frame.asp")
 frame = browser.frame_by(id: "C09C4E4404314AAEAE85928EAC109A93")
 frame.current_title # => "HTML frame tag"
 ```
@@ -852,7 +852,7 @@ frame.current_title # => "HTML frame tag"
 Returns current frame's html.
 
 ```ruby
-browser.goto("https://www.w3schools.com/tags/tag_frame.asp")
+browser.go_to("https://www.w3schools.com/tags/tag_frame.asp")
 frame = browser.frame_by(id: "C09C4E4404314AAEAE85928EAC109A93")
 frame.body # => "<html><head></head><body></body></html>"
 ```
@@ -862,7 +862,7 @@ frame.body # => "<html><head></head><body></body></html>"
 Returns current frame's doctype.
 
 ```ruby
-browser.goto("https://www.w3schools.com/tags/tag_frame.asp")
+browser.go_to("https://www.w3schools.com/tags/tag_frame.asp")
 browser.main_frame.doctype # => "<!DOCTYPE html>"
 ```
 
@@ -873,7 +873,7 @@ Sets a content of a given frame.
   * html `String`
 
 ```ruby
-browser.goto("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe")
+browser.go_to("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe")
 frame = browser.frames[1]
 frame.body # <html lang="en"><head><style>body {transition: opacity ease-in 0.2s; }...
 frame.set_content("<html><head></head><body><p>lol</p></body></html>")
@@ -902,7 +902,7 @@ browser.on(:dialog) do |dialog|
     dialog.dismiss
   end
 end
-browser.goto("https://google.com")
+browser.go_to("https://google.com")
 ```
 
 

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -17,7 +17,7 @@ module Ferrum
     extend Forwardable
     delegate %i[default_context] => :contexts
     delegate %i[targets create_target create_page page pages windows] => :default_context
-    delegate %i[goto back forward refresh reload stop wait_for_reload
+    delegate %i[go_to back forward refresh reload stop wait_for_reload
                 at_css at_xpath css xpath current_url current_title url title
                 body doctype set_content
                 headers cookies network
@@ -26,7 +26,7 @@ module Ferrum
                 frames frame_by main_frame
                 evaluate evaluate_on evaluate_async execute
                 add_script_tag add_style_tag bypass_csp
-                on] => :page
+                on goto] => :page
     delegate %i[default_user_agent] => :process
 
     attr_reader :client, :process, :contexts, :logger, :js_errors,

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -65,7 +65,7 @@ module Ferrum
       @browser.timeout
     end
 
-    def goto(url = nil)
+    def go_to(url = nil)
       options = { url: combine_url!(url) }
       options.merge!(referrer: referrer) if referrer
       response = command("Page.navigate", wait: GOTO_WAIT, **options)
@@ -81,6 +81,7 @@ module Ferrum
       pendings = network.traffic.select(&:pending?).map { |e| e.request.url }
       raise StatusError.new(options[:url], pendings) unless pendings.empty?
     end
+    alias goto go_to
 
     def close
       @headers.clear

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -35,7 +35,7 @@ module Ferrum
       it "supports capturing console.log" do
         begin
           browser = Browser.new(logger: logger)
-          browser.goto(base_url("/ferrum/console_log"))
+          browser.go_to(base_url("/ferrum/console_log"))
           expect(logger.string).to include("Hello world")
         ensure
           browser&.quit
@@ -47,7 +47,7 @@ module Ferrum
       begin
         defaults = Browser::Options::Chrome.options.except("disable-web-security")
         browser = Browser.new(ignore_default_browser_options: true, browser_options: defaults)
-        browser.goto(base_url("/ferrum/console_log"))
+        browser.go_to(base_url("/ferrum/console_log"))
       ensure
         browser&.quit
       end
@@ -66,7 +66,7 @@ module Ferrum
 
     it "raises an error and restarts the client if the client dies while executing a command" do
       expect { browser.crash }.to raise_error(Ferrum::DeadBrowserError)
-      browser.goto
+      browser.go_to
       expect(browser.body).to include("Hello world")
     end
 
@@ -76,26 +76,26 @@ module Ferrum
     end
 
     it "has a viewport size of 1024x768 by default" do
-      browser.goto
+      browser.go_to
 
       expect(browser.viewport_size).to eq([1024, 768])
     end
 
     it "allows the viewport to be resized" do
-      browser.goto
+      browser.go_to
       browser.resize(width: 200, height: 400)
       expect(browser.viewport_size).to eq([200, 400])
     end
 
     it "allows the viewport to be resized by fullscreen" do
-      browser.goto("/ferrum/custom_html_size")
+      browser.go_to("/ferrum/custom_html_size")
       expect(browser.viewport_size).to eq([1024, 768])
       browser.resize(fullscreen: true)
       expect(browser.viewport_size).to eq([1280, 1024])
     end
 
     it "allows the page to be scrolled" do
-      browser.goto("/ferrum/long_page")
+      browser.go_to("/ferrum/long_page")
       browser.resize(width: 10, height: 10)
       browser.mouse.scroll_to(200, 100)
       expect(
@@ -106,7 +106,7 @@ module Ferrum
     it "supports specifying viewport size with an option" do
       begin
         browser = Browser.new(window_size: [800, 600])
-        browser.goto(base_url)
+        browser.go_to(base_url)
         expect(browser.viewport_size).to eq([800, 600])
       ensure
         browser&.quit
@@ -114,7 +114,7 @@ module Ferrum
     end
 
     it "supports clicking precise coordinates" do
-      browser.goto("/ferrum/click_coordinates")
+      browser.go_to("/ferrum/click_coordinates")
       browser.mouse.click(x: 100, y: 150)
       expect(browser.body).to include("x: 100, y: 150")
     end
@@ -144,7 +144,7 @@ module Ferrum
           browser = Browser.new(base_url: base_url,
                                 extensions: [File.expand_path("support/geolocation.js", __dir__)])
 
-          browser.goto("/ferrum/requiring_custom_extension")
+          browser.go_to("/ferrum/requiring_custom_extension")
 
           expect(
             browser.body
@@ -167,7 +167,7 @@ module Ferrum
           browser = Browser.new(base_url: base_url,
                                 extensions: [{source: "window.secret = 'top'"}])
 
-          browser.goto("/ferrum/requiring_custom_extension")
+          browser.go_to("/ferrum/requiring_custom_extension")
 
           expect(browser.evaluate(%(window.secret))).to eq("top")
         ensure
@@ -178,7 +178,7 @@ module Ferrum
       it "errors when extension is unavailable" do
         begin
           browser = Browser.new(extensions: [File.expand_path("../support/non_existent.js", __dir__)])
-          expect { browser.goto }.to raise_error(Errno::ENOENT)
+          expect { browser.go_to }.to raise_error(Errno::ENOENT)
         ensure
           browser&.quit
         end
@@ -222,13 +222,13 @@ module Ferrum
       end
 
       it "propagates a Javascript error during page load to a ruby exception" do
-        expect { browser.goto("/ferrum/js_error") }.to raise_error(Ferrum::JavaScriptError)
+        expect { browser.go_to("/ferrum/js_error") }.to raise_error(Ferrum::JavaScriptError)
       end
 
       it "does not propagate a Javascript error to ruby if error raising disabled" do
         begin
           browser = Browser.new(base_url: base_url, js_errors: false)
-          browser.goto("/ferrum/js_error")
+          browser.go_to("/ferrum/js_error")
           browser.execute "setTimeout(function() { omg }, 0)"
           sleep 0.1
           expect(browser.body).to include("hello")
@@ -241,7 +241,7 @@ module Ferrum
         begin
           browser = Browser.new(base_url: base_url, js_errors: false)
           browser.restart
-          browser.goto("/ferrum/js_error")
+          browser.go_to("/ferrum/js_error")
           browser.execute "setTimeout(function() { omg }, 0)"
           sleep 0.1
           expect(browser.body).to include("hello")
@@ -255,17 +255,17 @@ module Ferrum
       let(:port) { server.port }
 
       it "do not occur when DNS correct" do
-        expect { browser.goto("http://localhost:#{port}/") }.not_to raise_error
+        expect { browser.go_to("http://localhost:#{port}/") }.not_to raise_error
       end
 
       it "handles when DNS incorrect" do
-        expect { browser.goto("http://nope:#{port}/") }.to raise_error(Ferrum::StatusError)
+        expect { browser.go_to("http://nope:#{port}/") }.to raise_error(Ferrum::StatusError)
       end
 
       it "has a descriptive message when DNS incorrect" do
         url = "http://nope:#{port}/"
         expect {
-          browser.goto(url)
+          browser.go_to(url)
         }.to raise_error(
           Ferrum::StatusError,
           %(Request to #{url} failed to reach server, check DNS and/or server status)
@@ -277,7 +277,7 @@ module Ferrum
           old_timeout = browser.timeout
           browser.timeout = 2
           expect {
-            browser.goto("/ferrum/visit_timeout")
+            browser.go_to("/ferrum/visit_timeout")
           }.to raise_error(
             Ferrum::StatusError,
             %r{there are still pending connections: http://.*/ferrum/really_slow}
@@ -293,7 +293,7 @@ module Ferrum
           browser.timeout = 0.1
 
           expect {
-            browser.goto("/ferrum/really_slow")
+            browser.go_to("/ferrum/really_slow")
           }.to raise_error(
             Ferrum::StatusError,
             %r{there are still pending connections: http://.*/ferrum/really_slow}
@@ -307,7 +307,7 @@ module Ferrum
         begin
           old_timeout = browser.timeout
           browser.timeout = 4
-          expect { browser.goto("/ferrum/really_slow") }.not_to raise_error
+          expect { browser.go_to("/ferrum/really_slow") }.not_to raise_error
         ensure
           browser.timeout = old_timeout
         end
@@ -317,7 +317,7 @@ module Ferrum
     it "allows the driver to have a fixed port" do
       begin
         browser = Browser.new(port: 12345)
-        browser.goto(base_url)
+        browser.go_to(base_url)
 
         expect { TCPServer.new("127.0.0.1", 12345) }.to raise_error(Errno::EADDRINUSE)
       ensure
@@ -329,7 +329,7 @@ module Ferrum
       with_external_browser do |url|
         begin
           browser = Browser.new(url: url)
-          browser.goto(base_url)
+          browser.go_to(base_url)
           expect(browser.body).to include("Hello world!")
         ensure
           browser&.quit
@@ -342,7 +342,7 @@ module Ferrum
         # Use custom host "pointing" to localhost in /etc/hosts or iptables for this.
         # https://superuser.com/questions/516208/how-to-change-ip-address-to-point-to-localhost
         browser = Browser.new(host: ENV["BROWSER_TEST_HOST"], port: 12345)
-        browser.goto(base_url)
+        browser.go_to(base_url)
 
         expect {
           TCPServer.new(ENV["BROWSER_TEST_HOST"], 12345)
@@ -353,7 +353,7 @@ module Ferrum
     end
 
     it "lists the open windows" do
-      browser.goto
+      browser.go_to
 
       browser.execute <<~JS
         window.open("/ferrum/simple", "popup")
@@ -387,7 +387,7 @@ module Ferrum
 
     context "a new window inherits settings" do
       it "inherits size" do
-        browser.goto
+        browser.go_to
         browser.resize(width: 1200, height: 800)
         page = browser.create_page
         expect(page.viewport_size).to eq [1200, 800]
@@ -395,7 +395,7 @@ module Ferrum
     end
 
     it "resizes windows" do
-      browser.goto
+      browser.go_to
 
       expect(browser.targets.size).to eq(1)
 
@@ -415,7 +415,7 @@ module Ferrum
     end
 
     it "clears local storage after reset" do
-      browser.goto
+      browser.go_to
       browser.execute <<~JS
         localStorage.setItem("key", "value");
       JS
@@ -427,7 +427,7 @@ module Ferrum
 
       browser.reset
 
-      browser.goto
+      browser.go_to
       value = browser.evaluate <<~JS
         localStorage.getItem("key");
       JS
@@ -436,13 +436,13 @@ module Ferrum
 
     context "evaluate" do
       it "can return an element" do
-        browser.goto("/ferrum/type")
+        browser.go_to("/ferrum/type")
         element = browser.evaluate(%(document.getElementById("empty_input")))
         expect(element).to eq(browser.at_css("#empty_input"))
       end
 
       it "can return structures with elements" do
-        browser.goto("/ferrum/type")
+        browser.go_to("/ferrum/type")
         result = browser.evaluate <<~JS
           {
             a: document.getElementById("empty_input"),
@@ -522,14 +522,14 @@ module Ferrum
     end
 
     it "synchronizes page loads properly" do
-      browser.goto("/ferrum/index")
+      browser.go_to("/ferrum/index")
       browser.at_xpath("//a[text() = 'JS redirect']").click
       sleep 0.1
       expect(browser.body).to include("Hello world")
     end
 
     it "does not run into content quads error" do
-      browser.goto("/ferrum/index")
+      browser.go_to("/ferrum/index")
       Node.any_instance.stub(:get_content_quads)
                        .and_raise(Ferrum::BrowserError, 'message' => 'Could not compute content quads')
       browser.at_xpath("//a[text() = 'JS redirect']").click
@@ -537,53 +537,53 @@ module Ferrum
     end
 
     it "returns BR as new line in #text" do
-      browser.goto("/ferrum/simple")
+      browser.go_to("/ferrum/simple")
       el = browser.at_css("#break")
       expect(el.inner_text).to eq("Foo\nBar")
       expect(browser.at_css("#break").text).to eq("FooBar")
     end
 
     it "handles hash changes" do
-      browser.goto("/#omg")
+      browser.go_to("/#omg")
       expect(browser.current_url).to match(%r{/#omg$})
       browser.execute <<-JS
         window.onhashchange = function() { window.last_hashchange = window.location.hash }
       JS
-      browser.goto("/#foo")
+      browser.go_to("/#foo")
       expect(browser.current_url).to match(%r{/#foo$})
       expect(browser.evaluate("window.last_hashchange")).to eq("#foo")
     end
 
     context "current_url" do
       it "supports whitespace characters" do
-        browser.goto("/ferrum/arbitrary_path/200/foo%20bar%20baz")
+        browser.go_to("/ferrum/arbitrary_path/200/foo%20bar%20baz")
         expect(browser.current_url).to eq(base_url("/ferrum/arbitrary_path/200/foo%20bar%20baz"))
       end
 
       it "supports escaped characters" do
-        browser.goto("/ferrum/arbitrary_path/200/foo?a%5Bb%5D=c")
+        browser.go_to("/ferrum/arbitrary_path/200/foo?a%5Bb%5D=c")
         expect(browser.current_url).to eq(base_url("/ferrum/arbitrary_path/200/foo?a%5Bb%5D=c"))
       end
 
       it "supports url in parameter" do
-        browser.goto("/ferrum/arbitrary_path/200/foo%20asd?a=http://example.com/asd%20asd")
+        browser.go_to("/ferrum/arbitrary_path/200/foo%20asd?a=http://example.com/asd%20asd")
         expect(browser.current_url).to eq(base_url("/ferrum/arbitrary_path/200/foo%20asd?a=http://example.com/asd%20asd"))
       end
 
       it "supports restricted characters ' []:/+&='" do
-        browser.goto("/ferrum/arbitrary_path/200/foo?a=%20%5B%5D%3A%2F%2B%26%3D")
+        browser.go_to("/ferrum/arbitrary_path/200/foo?a=%20%5B%5D%3A%2F%2B%26%3D")
         expect(browser.current_url).to eq(base_url("/ferrum/arbitrary_path/200/foo?a=%20%5B%5D%3A%2F%2B%26%3D"))
       end
 
       it "returns about:blank when on about:blank" do
-        browser.goto("about:blank")
+        browser.go_to("about:blank")
         expect(browser.current_url).to eq("about:blank")
       end
     end
 
     context "window switching support" do
       it "waits for the window to load" do
-        browser.goto
+        browser.go_to
 
         browser.execute <<-JS
           window.open("/ferrum/slow", "popup")
@@ -595,7 +595,7 @@ module Ferrum
       end
 
       it "can access a second window of the same name" do
-        browser.goto
+        browser.go_to
 
         browser.execute <<-JS
           window.open("/ferrum/simple", "popup")
@@ -620,13 +620,13 @@ module Ferrum
     end
 
     it "handles obsolete node during an attach_file", skip: true do
-      browser.goto("/ferrum/attach_file")
+      browser.go_to("/ferrum/attach_file")
       browser.attach_file "file", __FILE__
     end
 
     context "whitespace stripping tests", skip: true do
       before do
-        browser.goto("/ferrum/filter_text_test")
+        browser.go_to("/ferrum/filter_text_test")
       end
 
       it "gets text" do
@@ -648,7 +648,7 @@ module Ferrum
 
     context "supports accessing element properties" do
       before do
-        browser.goto("/ferrum/attributes_properties")
+        browser.go_to("/ferrum/attributes_properties")
       end
 
       it "gets property innerHTML" do
@@ -669,7 +669,7 @@ module Ferrum
 
     context "SVG tests" do
       before do
-        browser.goto("/ferrum/svg_test")
+        browser.go_to("/ferrum/svg_test")
       end
 
       it "gets text from tspan node" do
@@ -678,7 +678,7 @@ module Ferrum
     end
 
     it "can go back when history state has been pushed" do
-      browser.goto
+      browser.go_to
       browser.execute(%(window.history.pushState({foo: "bar"}, "title", "bar2.html");))
       expect(browser.current_url).to eq(base_url("/bar2.html"))
       expect { browser.back }.not_to raise_error
@@ -686,7 +686,7 @@ module Ferrum
     end
 
     it "can go forward when history state is used" do
-      browser.goto
+      browser.go_to
       browser.execute(%(window.history.pushState({foo: "bar"}, "title", "bar2.html");))
       expect(browser.current_url).to eq(base_url("/bar2.html"))
       # don't use #back here to isolate the test
@@ -697,7 +697,7 @@ module Ferrum
     end
 
     it "waits for page to be reloaded" do
-      browser.goto("/ferrum/auto_refresh")
+      browser.go_to("/ferrum/auto_refresh")
       expect(browser.body).to include("Visited 0 times")
 
       browser.wait_for_reload(5)
@@ -706,7 +706,7 @@ module Ferrum
     end
 
     it "can bypass csp headers" do
-      browser.goto("/csp")
+      browser.go_to("/csp")
       browser.add_script_tag(content: "window.__injected = 42")
       expect(browser.evaluate("window.__injected")).to be_nil
 
@@ -742,7 +742,7 @@ module Ferrum
           <<-RUBY
             require "ferrum"
             browser = Ferrum::Browser.new
-            browser.goto("http://example.com")
+            browser.go_to("http://example.com")
             puts "Please type enter"
             sleep 1
             browser.current_url

--- a/spec/cookies_spec.rb
+++ b/spec/cookies_spec.rb
@@ -4,7 +4,7 @@ module Ferrum
   describe Browser do
     context "cookies support" do
       it "returns set cookies" do
-        browser.goto("/set_cookie")
+        browser.go_to("/set_cookie")
 
         cookie = browser.cookies["stealth"]
         expect(cookie.name).to eq("stealth")
@@ -20,7 +20,7 @@ module Ferrum
 
       it "can set cookies" do
         browser.cookies.set(name: "stealth", value: "omg")
-        browser.goto("/get_cookie")
+        browser.go_to("/get_cookie")
         expect(browser.body).to include("omg")
       end
 
@@ -33,10 +33,10 @@ module Ferrum
           samesite: "None"
         )
 
-        browser.goto("/get_cookie")
+        browser.go_to("/get_cookie")
         expect(browser.body).to_not include("omg")
 
-        browser.goto("/ferrum/get_cookie")
+        browser.go_to("/ferrum/get_cookie")
         expect(browser.body).to include("omg")
 
         expect(browser.cookies["stealth"].path).to eq("/ferrum")
@@ -45,32 +45,32 @@ module Ferrum
       end
 
       it "can remove a cookie" do
-        browser.goto("/set_cookie")
+        browser.go_to("/set_cookie")
 
-        browser.goto("/get_cookie")
+        browser.go_to("/get_cookie")
         expect(browser.body).to include("test_cookie")
 
         browser.cookies.remove(name: "stealth")
 
-        browser.goto("/get_cookie")
+        browser.go_to("/get_cookie")
         expect(browser.body).to_not include("test_cookie")
       end
 
       it "can clear cookies" do
-        browser.goto("/set_cookie")
+        browser.go_to("/set_cookie")
 
-        browser.goto("/get_cookie")
+        browser.go_to("/get_cookie")
         expect(browser.body).to include("test_cookie")
 
         browser.cookies.clear
 
-        browser.goto("/get_cookie")
+        browser.go_to("/get_cookie")
         expect(browser.body).to_not include("test_cookie")
       end
 
       it "can set cookies with an expires time" do
         time = Time.at(Time.now.to_i + 10000)
-        browser.goto
+        browser.go_to
         browser.cookies.set(name: "foo", value: "bar", expires: time)
         expect(browser.cookies["foo"].expires).to eq(time)
       end
@@ -80,10 +80,10 @@ module Ferrum
         browser.cookies.set(name: "stealth", value: "127.0.0.1")
         browser.cookies.set(name: "stealth", value: "localhost", domain: "localhost")
 
-        browser.goto("http://localhost:#{port}/ferrum/get_cookie")
+        browser.go_to("http://localhost:#{port}/ferrum/get_cookie")
         expect(browser.body).to include("localhost")
 
-        browser.goto("http://127.0.0.1:#{port}/ferrum/get_cookie")
+        browser.go_to("http://127.0.0.1:#{port}/ferrum/get_cookie")
         expect(browser.body).to include("127.0.0.1")
       end
 
@@ -93,10 +93,10 @@ module Ferrum
           browser.cookies.set(name: "stealth", value: "123456", domain: "localhost")
 
           port = server.port
-          browser.goto("http://localhost:#{port}/ferrum/get_cookie")
+          browser.go_to("http://localhost:#{port}/ferrum/get_cookie")
           expect(browser.body).to include("123456")
 
-          browser.goto("http://127.0.0.1:#{port}/ferrum/get_cookie")
+          browser.go_to("http://127.0.0.1:#{port}/ferrum/get_cookie")
           expect(browser.body).not_to include("123456")
         ensure
           browser&.quit

--- a/spec/dialog_spec.rb
+++ b/spec/dialog_spec.rb
@@ -4,7 +4,7 @@ module Ferrum
   describe Browser do
     context "dialog support" do
       it "matches on partial strings" do
-        browser.goto("/ferrum/with_js")
+        browser.go_to("/ferrum/with_js")
         browser.on(:dialog) do |dialog|
           if dialog.match?(Regexp.escape("[reg.exp] (chara©+er$)"))
             dialog.accept
@@ -19,7 +19,7 @@ module Ferrum
       end
 
       it "matches on regular expressions" do
-        browser.goto("/ferrum/with_js")
+        browser.go_to("/ferrum/with_js")
         browser.on(:dialog) do |dialog|
           if dialog.match?(/^.t.ext.*\[\w{3}\.\w{3}\]/i)
             dialog.accept
@@ -34,7 +34,7 @@ module Ferrum
       end
 
       it "works with nested modals" do
-        browser.goto("/ferrum/with_js")
+        browser.go_to("/ferrum/with_js")
         browser.on(:dialog) do |dialog|
           if dialog.match?("Are you sure?")
             dialog.accept
@@ -51,7 +51,7 @@ module Ferrum
       end
 
       it "works with second window" do
-        browser.goto
+        browser.go_to
 
         browser.execute <<-JS
           window.open("/ferrum/with_js", "popup")

--- a/spec/dragging_spec.rb
+++ b/spec/dragging_spec.rb
@@ -3,7 +3,7 @@
 module Ferrum
   describe Browser do
     context "dragging support", skip: true do
-      before { browser.goto("/ferrum/drag") }
+      before { browser.go_to("/ferrum/drag") }
 
       it "supports drag_to" do
         draggable = browser.at_css("#drag_to #draggable")

--- a/spec/frame_spec.rb
+++ b/spec/frame_spec.rb
@@ -4,31 +4,31 @@ module Ferrum
   describe Browser do
     context "frame support" do
       it "supports selection by index" do
-        browser.goto("/ferrum/frames")
+        browser.go_to("/ferrum/frames")
         frame = browser.at_xpath("//iframe").frame
         expect(frame.url).to end_with("/ferrum/slow")
       end
 
       it "supports selection by element" do
-        browser.goto("/ferrum/frames")
+        browser.go_to("/ferrum/frames")
         frame = browser.at_css("iframe[name]").frame
         expect(frame.url).to end_with("/ferrum/slow")
       end
 
       it "supports selection by element without name or id" do
-        browser.goto("/ferrum/frames")
+        browser.go_to("/ferrum/frames")
         frame = browser.at_css("iframe:not([name]):not([id])").frame
         expect(frame.url).to end_with("/ferrum/headers")
       end
 
       it "supports selection by element with id but no name" do
-        browser.goto("/ferrum/frames")
+        browser.go_to("/ferrum/frames")
         frame = browser.at_css("iframe[id]:not([name])").frame
         expect(frame.url).to end_with("/ferrum/get_cookie")
       end
 
       it "waits for the frame to load" do
-        browser.goto
+        browser.go_to
         browser.execute <<-JS
           document.body.innerHTML += "<iframe src='/ferrum/slow' name='frame'>"
         JS
@@ -41,7 +41,7 @@ module Ferrum
       end
 
       it "waits for the cross-domain frame to load" do
-        browser.goto("/ferrum/frames")
+        browser.go_to("/ferrum/frames")
         expect(browser.current_url).to eq(base_url("/ferrum/frames"))
         frame = browser.at_xpath("//iframe[@name='frame']").frame
 
@@ -53,7 +53,7 @@ module Ferrum
 
       context "with src == about:blank" do
         it "doesn't hang if no document created" do
-          browser.goto
+          browser.go_to
           browser.execute <<-JS
             document.body.innerHTML += "<iframe src='about:blank' name='frame'>"
           JS
@@ -62,7 +62,7 @@ module Ferrum
         end
 
         it "doesn't hang if built by JS" do
-          browser.goto
+          browser.go_to
           browser.execute <<-JS
             document.body.innerHTML += "<iframe src='about:blank' name='frame'>";
             var iframeDocument = document.querySelector("iframe[name='frame']").contentWindow.document;
@@ -78,7 +78,7 @@ module Ferrum
 
       context "with no src attribute" do
         it "doesn't hang if the srcdoc attribute is used" do
-          browser.goto
+          browser.go_to
           browser.execute <<-JS
             document.body.innerHTML += "<iframe srcdoc='<p>Hello Frame</p>' name='frame'>"
           JS
@@ -87,7 +87,7 @@ module Ferrum
         end
 
         it "doesn't hang if the frame is filled by JS" do
-          browser.goto
+          browser.go_to
           browser.execute <<-JS
             document.body.innerHTML += "<iframe id='frame' name='frame'>"
           JS
@@ -105,7 +105,7 @@ module Ferrum
 
       context "#add_script_tag" do
         it "adds by url" do
-          browser.goto
+          browser.go_to
           expect {
             browser.evaluate("$('a').first().text()")
           }.to raise_error(Ferrum::JavaScriptError)
@@ -116,7 +116,7 @@ module Ferrum
         end
 
         it "adds by path" do
-          browser.goto
+          browser.go_to
           path = "#{Ferrum::Application::FERRUM_PUBLIC}/jquery-1.11.3.min.js"
           expect {
             browser.evaluate("$('a').first().text()")
@@ -128,7 +128,7 @@ module Ferrum
         end
 
         it "adds by content" do
-          browser.goto
+          browser.go_to
 
           browser.add_script_tag(content: "function yay() { return 'yay!'; }")
 
@@ -146,7 +146,7 @@ module Ferrum
         }
 
         it "adds by url" do
-          browser.goto
+          browser.go_to
           expect(browser.evaluate(font_size)).to eq("16px")
 
           browser.add_style_tag(url: "/ferrum/add_style_tag.css")
@@ -155,7 +155,7 @@ module Ferrum
         end
 
         it "adds by path" do
-          browser.goto
+          browser.go_to
           path = "#{Ferrum::Application::FERRUM_PUBLIC}/add_style_tag.css"
           expect(browser.evaluate(font_size)).to eq("16px")
 
@@ -165,7 +165,7 @@ module Ferrum
         end
 
         it "adds by content" do
-          browser.goto
+          browser.go_to
 
           browser.add_style_tag(content: "a { font-size: 20px; }")
 
@@ -174,7 +174,7 @@ module Ferrum
       end
 
       it "supports clicking in a frame", skip: true do
-        browser.goto
+        browser.go_to
         browser.execute <<-JS
           document.body.innerHTML += "<iframe src='/ferrum/click_test' name='frame'>"
         JS
@@ -187,7 +187,7 @@ module Ferrum
       end
 
       it "supports clicking in a frame with padding", skip: true do
-        browser.goto
+        browser.go_to
         browser.execute <<-JS
           document.body.innerHTML += "<iframe src='/ferrum/click_test' name='padded_frame' style='padding:100px;'>"
         JS
@@ -199,7 +199,7 @@ module Ferrum
       end
 
       it "supports clicking in a frame nested in a frame", skip: true do
-        browser.goto
+        browser.go_to
 
         # The padding on the frame here is to differ the sizes of the two
         # frames, ensuring that their offsets are being calculated seperately.
@@ -219,7 +219,7 @@ module Ferrum
       end
 
       it "does not wait forever for the frame to load" do
-        browser.goto
+        browser.go_to
 
         frame = browser.frame_by(name: "omg")
 
@@ -227,7 +227,7 @@ module Ferrum
       end
 
       it "can get the frames url" do
-        browser.goto("/ferrum/frames")
+        browser.go_to("/ferrum/frames")
 
         frame = browser.at_xpath("//iframe").frame
         expect(frame.url).to end_with("/ferrum/slow")
@@ -241,7 +241,7 @@ module Ferrum
       end
 
       it "gets page doctype" do
-        browser.goto("/ferrum/frames")
+        browser.go_to("/ferrum/frames")
         expect(browser.doctype).to eq("<!DOCTYPE html>")
 
         doctype_40 = %(<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">)
@@ -254,14 +254,14 @@ module Ferrum
 
       context "#xpath" do
         it "returns given nodes" do
-          browser.goto("/ferrum/with_js")
+          browser.go_to("/ferrum/with_js")
           p = browser.xpath("//p[@id='remove_me']")
 
           expect(p.size).to eq(1)
         end
 
         it "supports within" do
-          browser.goto("/ferrum/with_js")
+          browser.go_to("/ferrum/with_js")
           p = browser.xpath("//p[@id='with_content']").first
 
           links = browser.xpath("./a", within: p)
@@ -271,7 +271,7 @@ module Ferrum
         end
 
         it "throws an error on a wrong xpath" do
-          browser.goto("/ferrum/with_js")
+          browser.go_to("/ferrum/with_js")
 
           expect {
             browser.xpath("#remove_me")
@@ -279,7 +279,7 @@ module Ferrum
         end
 
         it "supports inside a given frame" do
-          browser.goto("/ferrum/frames")
+          browser.go_to("/ferrum/frames")
           browser.execute <<-JS
             document.body.innerHTML += "<iframe src='/ferrum/buttons' id='buttons_frame'>"
           JS
@@ -292,14 +292,14 @@ module Ferrum
 
       context "#at_xpath" do
         it "returns given nodes" do
-          browser.goto("/ferrum/with_js")
+          browser.go_to("/ferrum/with_js")
           p = browser.at_xpath("//p[@id='remove_me']")
 
           expect(p).not_to be_nil
         end
 
         it "supports within" do
-          browser.goto("/ferrum/with_js")
+          browser.go_to("/ferrum/with_js")
           p = browser.at_xpath("//p[@id='with_content']")
 
           link = browser.at_xpath("./a", within: p)
@@ -309,7 +309,7 @@ module Ferrum
         end
 
         it "throws an error on a wrong xpath" do
-          browser.goto("/ferrum/with_js")
+          browser.go_to("/ferrum/with_js")
 
           expect {
             browser.at_xpath("#remove_me")
@@ -317,7 +317,7 @@ module Ferrum
         end
 
         it "supports inside a given frame" do
-          browser.goto("/ferrum/frames")
+          browser.go_to("/ferrum/frames")
           browser.execute <<-JS
             document.body.innerHTML += "<iframe src='/ferrum/buttons' id='buttons_frame'>"
           JS
@@ -330,14 +330,14 @@ module Ferrum
 
       context "#css" do
         it "returns given nodes" do
-          browser.goto("/ferrum/with_js")
+          browser.go_to("/ferrum/with_js")
           p = browser.css("p#remove_me")
 
           expect(p.size).to eq(1)
         end
 
         it "supports within" do
-          browser.goto("/ferrum/with_js")
+          browser.go_to("/ferrum/with_js")
           p = browser.css("p#with_content").first
 
           links = browser.css("a", within: p)
@@ -347,7 +347,7 @@ module Ferrum
         end
 
         it "throws an error on an invalid selector" do
-          browser.goto("/ferrum/table")
+          browser.go_to("/ferrum/table")
 
           expect {
             browser.css("table tr:last")
@@ -355,7 +355,7 @@ module Ferrum
         end
 
         it "supports inside a given frame" do
-          browser.goto("/ferrum/frames")
+          browser.go_to("/ferrum/frames")
           browser.execute <<-JS
             document.body.innerHTML += "<iframe src='/ferrum/buttons' id='buttons_frame'>"
           JS
@@ -368,14 +368,14 @@ module Ferrum
 
       context "#at_css" do
         it "returns given nodes" do
-          browser.goto("/ferrum/with_js")
+          browser.go_to("/ferrum/with_js")
           p = browser.at_css("p#remove_me")
 
           expect(p).not_to be_nil
         end
 
         it "supports within" do
-          browser.goto("/ferrum/with_js")
+          browser.go_to("/ferrum/with_js")
           p = browser.at_css("p#with_content")
 
           link = browser.at_css("a", within: p)
@@ -385,7 +385,7 @@ module Ferrum
         end
 
         it "throws an error on an invalid selector" do
-          browser.goto("/ferrum/table")
+          browser.go_to("/ferrum/table")
 
           expect {
             browser.at_css("table tr:last")
@@ -393,7 +393,7 @@ module Ferrum
         end
 
         it "supports inside a given frame" do
-          browser.goto("/ferrum/frames")
+          browser.go_to("/ferrum/frames")
           browser.execute <<-JS
             document.body.innerHTML += "<iframe src='/ferrum/buttons' id='buttons_frame'>"
           JS

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -5,7 +5,7 @@ module Ferrum
     context "headers support" do
       it "allows headers to be set" do
         browser.headers.set("Cookie" => "foo=bar", "YourName" => "your_value")
-        browser.goto("/ferrum/headers")
+        browser.go_to("/ferrum/headers")
         expect(browser.body).to include("COOKIE: foo=bar")
         expect(browser.body).to include("YOURNAME: your_value")
       end
@@ -18,13 +18,13 @@ module Ferrum
 
       it "supports User-Agent" do
         browser.headers.set("User-Agent" => "foo")
-        browser.goto
+        browser.go_to
         expect(browser.evaluate("window.navigator.userAgent")).to eq("foo")
       end
 
       it "sets headers for all HTTP requests" do
         browser.headers.set("X-Omg" => "wat")
-        browser.goto
+        browser.go_to
         browser.execute <<-JS
           var request = new XMLHttpRequest();
           request.open("GET", "/ferrum/headers", false);
@@ -40,7 +40,7 @@ module Ferrum
       it "adds new headers" do
         browser.headers.set("User-Agent" => "Browser", "YourName" => "your_value")
         browser.headers.add({ "User-Agent" => "Super Browser", "Appended" => "true" })
-        browser.goto("/ferrum/headers")
+        browser.go_to("/ferrum/headers")
         expect(browser.body).to include("USER_AGENT: Super Browser")
         expect(browser.body).to include("YOURNAME: your_value")
         expect(browser.body).to include("APPENDED: true")
@@ -48,7 +48,7 @@ module Ferrum
 
       it "sets accept-language even if user-agent is not provided" do
         browser.headers.add({ "Accept-Language" => "esperanto" })
-        browser.goto("/ferrum/headers")
+        browser.go_to("/ferrum/headers")
         expect(browser.body).to include("USER_AGENT: #{browser.default_user_agent}")
         expect(browser.body).to match(/ACCEPT_LANGUAGE: esperanto/)
       end
@@ -59,7 +59,7 @@ module Ferrum
         browser.headers.add({ "Referer" => "http://google.com" }, permanent: false)
         browser.headers.add({ "TempA" => "a" }, permanent: false) # simply ignored
 
-        browser.goto("/ferrum/headers_with_ajax")
+        browser.go_to("/ferrum/headers_with_ajax")
         initial_request = browser.at_css("#initial_request").text
         ajax_request = browser.at_css("#ajax_request").text
 
@@ -76,7 +76,7 @@ module Ferrum
 
       it "keeps added headers on redirects" do
         browser.headers.add({ "X-Custom-Header" => "1" }, permanent: false)
-        browser.goto("/ferrum/redirect_to_headers")
+        browser.go_to("/ferrum/redirect_to_headers")
         expect(browser.body).to include("X_CUSTOM_HEADER: 1")
       end
 
@@ -87,7 +87,7 @@ module Ferrum
             "Host" => "foo.com",
             "User-Agent" => "foo"
           )
-          browser.goto("/ferrum/popup_headers")
+          browser.go_to("/ferrum/popup_headers")
           browser.at_xpath("//a[text()='pop up']").click
 
           page, _ = browser.windows(:last)
@@ -110,7 +110,7 @@ module Ferrum
           expect(page.body).to include("HOST: foo.com")
 
           browser.switch_to_window browser.windows.last
-          browser.goto("/ferrum/headers")
+          browser.go_to("/ferrum/headers")
           expect(browser.body).to include("USER_AGENT: foo")
           expect(browser.body).to include("COOKIE: foo=bar")
           expect(browser.body).to include("HOST: foo.com")
@@ -121,11 +121,11 @@ module Ferrum
           browser.headers.add("X-Custom-Header" => "1", permanent: false)
 
           browser.switch_to_window browser.windows.last
-          browser.goto("/ferrum/headers")
+          browser.go_to("/ferrum/headers")
           expect(browser.body).not_to include("X_CUSTOM_HEADER: 1")
 
           browser.switch_to_window browser.windows.first
-          browser.goto("/ferrum/headers")
+          browser.go_to("/ferrum/headers")
           expect(browser.body).to include("X_CUSTOM_HEADER: 1")
         end
 
@@ -135,27 +135,27 @@ module Ferrum
           browser.headers.add("Host" => "foo.com")
 
           browser.switch_to_window browser.windows.last
-          browser.goto("/ferrum/headers")
+          browser.go_to("/ferrum/headers")
           expect(browser.body).to include("HOST: foo.com")
           expect(browser.body).not_to include("X_CUSTOM_HEADER: 1")
 
           browser.switch_to_window browser.windows.first
-          browser.goto("/ferrum/headers")
+          browser.go_to("/ferrum/headers")
           expect(browser.body).to include("HOST: foo.com")
           expect(browser.body).to include("X_CUSTOM_HEADER: 1")
         end
 
         it "does not propagate temporary headers to new windows" do
-          browser.goto
+          browser.go_to
           browser.headers.add("X-Custom-Header" => "1", permanent: false)
           browser.create_page
 
           browser.switch_to_window browser.windows.last
-          browser.goto("/ferrum/headers")
+          browser.go_to("/ferrum/headers")
           expect(browser.body).not_to include("X_CUSTOM_HEADER: 1")
 
           browser.switch_to_window browser.windows.first
-          browser.goto("/ferrum/headers")
+          browser.go_to("/ferrum/headers")
           expect(browser.body).to include("X_CUSTOM_HEADER: 1")
         end
       end

--- a/spec/keyboard_spec.rb
+++ b/spec/keyboard_spec.rb
@@ -3,7 +3,7 @@
 module Ferrum
   describe Keyboard do
     context "has ability to send keys" do
-      before { browser.goto("/ferrum/type") }
+      before { browser.go_to("/ferrum/type") }
 
       it "sends keys to empty input" do
         input = browser.at_css("#empty_input")
@@ -167,7 +167,7 @@ module Ferrum
     context "type" do
       let(:delete_all) { [ [(Ferrum.mac? ? :alt : :ctrl), :shift, :right], :backspace ] }
 
-      before { browser.goto("/ferrum/set") }
+      before { browser.go_to("/ferrum/set") }
 
       it "sets contenteditable's content" do
         input = browser.at_css("#filled_div")
@@ -188,7 +188,7 @@ module Ferrum
       end
 
       it "sets a content editable childs content" do
-        browser.goto("/orig_with_js")
+        browser.go_to("/orig_with_js")
         input = browser.at_css("#existing_content_editable_child")
         input.click.type(" WYSIWYG")
         expect(input.text).to eq("Content WYSIWYG")
@@ -198,7 +198,7 @@ module Ferrum
         let(:input) { browser.at_css("#input") }
         let(:output) { browser.at_css("#output") }
 
-        before { browser.goto("/ferrum/input_events") }
+        before { browser.go_to("/ferrum/input_events") }
 
         it "calls event handlers in the correct order" do
           input.focus.type("a").blur
@@ -239,7 +239,7 @@ module Ferrum
       let(:change_me) { browser.at_css("#change_me") }
 
       before do
-        browser.goto("/ferrum/with_js")
+        browser.go_to("/ferrum/with_js")
         change_me.focus.type("Hello!")
       end
 
@@ -318,7 +318,7 @@ module Ferrum
     end
 
     context "date_fields" do
-      before { browser.goto("/ferrum/date_fields") }
+      before { browser.go_to("/ferrum/date_fields") }
 
       it "sets a date" do
         input = browser.at_css("#date_field")

--- a/spec/mouse_spec.rb
+++ b/spec/mouse_spec.rb
@@ -4,7 +4,7 @@ module Ferrum
   describe Mouse do
     context "mouse support", skip: true do
       before do
-        browser.goto("/ferrum/click_test")
+        browser.go_to("/ferrum/click_test")
       end
 
       after do
@@ -25,7 +25,7 @@ module Ferrum
       end
 
       it "fixes some weird layout issue that we are not entirely sure about the reason for" do
-        browser.goto("/ferrum/datepicker")
+        browser.go_to("/ferrum/datepicker")
         browser.at_css("#datepicker").set("2012-05-11")
         browser.at_xpath("//a[text() = 'some link']").click
       end
@@ -93,7 +93,7 @@ module Ferrum
       end
 
       context "with image maps", skip: true do
-        before { browser.goto("/ferrum/image_map") }
+        before { browser.go_to("/ferrum/image_map") }
 
         it "can click" do
           browser.at_css("map[name=testmap] area[shape=circle]").click
@@ -114,7 +114,7 @@ module Ferrum
 
       context "double click tests" do
         before do
-          browser.goto("/ferrum/double_click_test")
+          browser.go_to("/ferrum/double_click_test")
         end
 
         it "double clicks properly" do
@@ -131,7 +131,7 @@ module Ferrum
     end
 
     it "has no trouble clicking elements when the size of a document changes", skip: true do
-      browser.goto("/ferrum/long_page")
+      browser.go_to("/ferrum/long_page")
       browser.at_css("#penultimate").click
       browser.execute <<~JS
         el = document.getElementById("penultimate")
@@ -142,13 +142,13 @@ module Ferrum
     end
 
     it "handles clicks where the target is in view, but the document is smaller than the viewport" do
-      browser.goto("/ferrum/simple")
+      browser.go_to("/ferrum/simple")
       browser.at_xpath("//a[text() = 'Link']").click
       expect(browser.body).to include("Hello world")
     end
 
     it "handles clicks where a parent element has a border" do
-      browser.goto("/ferrum/table")
+      browser.go_to("/ferrum/table")
       browser.at_xpath("//a[text() = 'Link']").click
       expect(browser.body).to include("Hello world")
     end
@@ -165,7 +165,7 @@ module Ferrum
       }
 
       it "splits into steps" do
-        browser.goto("/ferrum/simple")
+        browser.go_to("/ferrum/simple")
         browser.mouse.move(x: 100, y: 100)
         browser.evaluate_async(tracking_code, browser.timeout)
 

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -5,7 +5,7 @@ module Ferrum
     let(:traffic) { browser.network.traffic }
 
     it "keeps track of network traffic" do
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
       urls = traffic.map { |e| e.request.url }
 
       expect(urls.grep(%r{/ferrum/jquery.min.js$}).size).to eq(1)
@@ -14,7 +14,7 @@ module Ferrum
     end
 
     it "gets response body" do
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
       responses = traffic.map(&:response)
 
       expect(responses.size).to eq(4)
@@ -38,7 +38,7 @@ module Ferrum
         request.match?(/unwanted/) ? request.abort : request.continue
       end
 
-      browser.goto("/ferrum/url_blacklist")
+      browser.go_to("/ferrum/url_blacklist")
 
       blocked_urls = traffic.select(&:blocked?).map { |e| e.request.url }
 
@@ -46,20 +46,20 @@ module Ferrum
     end
 
     it "captures responses" do
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
 
       expect(traffic.last.response.status).to eq(200)
     end
 
     it "captures errors" do
-      browser.goto("/ferrum/with_ajax_fail")
+      browser.go_to("/ferrum/with_ajax_fail")
       expect(browser.at_xpath("//h1[text() = 'Done']")).to be
 
       expect(traffic.last.error).to be
     end
 
     it "captures refused connection errors" do
-      browser.goto("/ferrum/with_ajax_connection_refused")
+      browser.go_to("/ferrum/with_ajax_connection_refused")
       expect(browser.at_xpath("//h1[text() = 'Error']")).to be
 
       expect(traffic.last.error).to be
@@ -68,25 +68,25 @@ module Ferrum
     end
 
     it "keeps a running list between multiple web page views" do
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
       expect(traffic.length).to eq(4)
 
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
       expect(traffic.length).to eq(8)
     end
 
     it "gets cleared on restart" do
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
       expect(traffic.length).to eq(4)
 
       browser.restart
 
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
       expect(traffic.length).to eq(4)
     end
 
     it "gets cleared when being cleared" do
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
       expect(traffic.length).to eq(4)
 
       browser.network.clear(:traffic)
@@ -100,7 +100,7 @@ module Ferrum
         request.match?(/unwanted/) ? request.abort : request.continue
       end
 
-      browser.goto("/ferrum/url_blacklist")
+      browser.go_to("/ferrum/url_blacklist")
 
       expect(traffic.select(&:blocked?).length).to eq(3)
 
@@ -110,7 +110,7 @@ module Ferrum
     end
 
     it "counts network traffic for each loaded resource" do
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
       responses = traffic.map(&:response)
       resources_size = {
         %r{/ferrum/jquery.min.js$}    => File.size(PROJECT_ROOT + "/spec/support/public/jquery-1.11.3.min.js"),
@@ -127,7 +127,7 @@ module Ferrum
     it "can clear memory cache" do
       browser.network.clear(:cache)
 
-      browser.goto("/ferrum/cacheable")
+      browser.go_to("/ferrum/cacheable")
       traffic = browser.network.traffic
       expect(traffic.length).to eq(1)
       expect(browser.network.status).to eq(200)
@@ -143,7 +143,7 @@ module Ferrum
     end
 
     it "waits for network idle" do
-      browser.goto("/show_cookies")
+      browser.go_to("/show_cookies")
       expect(browser.body).not_to include("test_cookie")
 
       browser.at_xpath("//button[text() = 'Set cookie slow']").click
@@ -155,22 +155,22 @@ module Ferrum
 
     context "status code support" do
       it "determines status from the simple response" do
-        browser.goto("/ferrum/status/500")
+        browser.go_to("/ferrum/status/500")
         expect(browser.network.status).to eq(500)
       end
 
       it "determines status code when the page has a few resources" do
-        browser.goto("/ferrum/with_different_resources")
+        browser.go_to("/ferrum/with_different_resources")
         expect(browser.network.status).to eq(200)
       end
 
       it "determines status code even after redirect" do
-        browser.goto("/ferrum/redirect")
+        browser.go_to("/ferrum/redirect")
         expect(browser.network.status).to eq(200)
       end
 
       it "determines status code when user goes to a page by using a link on it" do
-        browser.goto("/ferrum/with_different_resources")
+        browser.go_to("/ferrum/with_different_resources")
 
         browser.at_xpath("//a[text() = 'Go to 500']").click
 
@@ -178,7 +178,7 @@ module Ferrum
       end
 
       it "determines properly status when user goes through a few pages" do
-        browser.goto("/ferrum/with_different_resources")
+        browser.go_to("/ferrum/with_different_resources")
 
         browser.at_xpath("//a[text() = 'Go to 200']").click
         browser.at_xpath("//a[text() = 'Go to 201']").click
@@ -191,7 +191,7 @@ module Ferrum
 
     context "authentication support" do
       it "denies without credentials" do
-        browser.goto("/ferrum/basic_auth")
+        browser.go_to("/ferrum/basic_auth")
 
         expect(browser.network.status).to eq(401)
         expect(browser.body).not_to include("Welcome, authenticated client")
@@ -200,7 +200,7 @@ module Ferrum
       it "allows with given credentials" do
         browser.network.authorize(user: "login", password: "pass")
 
-        browser.goto("/ferrum/basic_auth")
+        browser.go_to("/ferrum/basic_auth")
 
         expect(browser.network.status).to eq(200)
         expect(browser.body).to include("Welcome, authenticated client")
@@ -210,7 +210,7 @@ module Ferrum
         browser.network.authorize(user: "login", password: "pass")
         browser.headers.set("Cuprite" => "true")
 
-        browser.goto("/ferrum/basic_auth")
+        browser.go_to("/ferrum/basic_auth")
 
         expect(browser.network.status).to eq(200)
         expect(browser.body).to include("Welcome, authenticated client")
@@ -219,7 +219,7 @@ module Ferrum
       it "denies with wrong credentials" do
         browser.network.authorize(user: "user", password: "pass!")
 
-        browser.goto("/ferrum/basic_auth")
+        browser.go_to("/ferrum/basic_auth")
 
         expect(browser.network.status).to eq(401)
         expect(browser.body).not_to include("Welcome, authenticated client")
@@ -228,7 +228,7 @@ module Ferrum
       it "allows on POST request" do
         browser.network.authorize(user: "login", password: "pass")
 
-        browser.goto("/ferrum/basic_auth")
+        browser.go_to("/ferrum/basic_auth")
         browser.at_css(%([type="submit"])).click
 
         expect(browser.network.status).to eq(200)
@@ -243,7 +243,7 @@ module Ferrum
           request.match?(/unwanted/) ? request.abort : request.continue
         end
 
-        browser.goto("/ferrum/url_blacklist")
+        browser.go_to("/ferrum/url_blacklist")
 
         expect(browser.network.status).to eq(200)
         expect(browser.body).to include("We are loading some unwanted action here")
@@ -258,7 +258,7 @@ module Ferrum
           request.match?(/.*wanted/) ? request.abort : request.continue
         end
 
-        browser.goto("/ferrum/url_whitelist")
+        browser.go_to("/ferrum/url_whitelist")
 
         expect(browser.network.status).to eq(200)
         expect(browser.body).to include("We are loading some wanted action here")
@@ -276,7 +276,7 @@ module Ferrum
           request.match?(%r{url_whitelist|/wanted}) ? request.continue : request.abort
         end
 
-        browser.goto("/ferrum/url_whitelist")
+        browser.go_to("/ferrum/url_whitelist")
 
         expect(browser.network.status).to eq(200)
         expect(browser.body).to include("We are loading some wanted action here")
@@ -294,7 +294,7 @@ module Ferrum
           request.match?(%r{url_whitelist|/.*wanted}) ? request.continue : request.abort
         end
 
-        browser.goto("/ferrum/url_whitelist")
+        browser.go_to("/ferrum/url_whitelist")
 
         expect(browser.network.status).to eq(200)
         expect(browser.body).to include("We are loading some wanted action here")
@@ -312,7 +312,7 @@ module Ferrum
           request.respond(body: "<h1>custom content that is more than 45 characters</h1>")
         end
 
-        browser.goto("/ferrum/non_existing")
+        browser.go_to("/ferrum/non_existing")
 
         expect(browser.network.status).to eq(200)
         expect(browser.body).to include("content")

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -3,7 +3,7 @@
 module Ferrum
   describe Node do
     it "raises an error if the element has been removed from the DOM" do
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
       node = browser.at_css("#remove_me")
       expect(node.text).to eq("Remove me")
       browser.at_css("#remove").click
@@ -11,14 +11,14 @@ module Ferrum
     end
 
     it "raises an error if the element was on a previous page" do
-      browser.goto("/ferrum/index")
+      browser.go_to("/ferrum/index")
       node = browser.at_xpath(".//a")
       browser.execute "window.location = 'about:blank'"
       expect { node.text }.to raise_error(Ferrum::NodeNotFoundError)
     end
 
     it "raises an error if the element is not visible", skip: true do
-      browser.goto("/ferrum/index")
+      browser.go_to("/ferrum/index")
       browser.execute <<~JS
         document.querySelector("a[href=js_redirect]").style.display = "none"
       JS
@@ -31,20 +31,20 @@ module Ferrum
     end
 
     it "hovers an element before clicking it" do
-      browser.goto("/ferrum/with_js")
+      browser.go_to("/ferrum/with_js")
       browser.at_xpath("//a[span[text() = 'Hidden link']]").click
       expect(browser.current_url).to eq(base_url("/"))
     end
 
     it "works correctly when JSON is overwritten" do
-      browser.goto("/ferrum/index")
+      browser.go_to("/ferrum/index")
       browser.execute("JSON = {};")
       expect { browser.at_xpath("//a[text() = 'JS redirect']") }.not_to raise_error
     end
 
     context "when the element is not in the viewport" do
       before do
-        browser.goto("/ferrum/with_js")
+        browser.go_to("/ferrum/with_js")
       end
 
       # FIXME:
@@ -67,7 +67,7 @@ module Ferrum
 
     context "when the element is not in the viewport of parent element", skip: true do
       before do
-        browser.goto("/ferrum/scroll")
+        browser.go_to("/ferrum/scroll")
       end
 
       it "scrolls into view" do
@@ -84,7 +84,7 @@ module Ferrum
 
     describe "Node#[]" do
       before do
-        browser.goto("/ferrum/attributes_properties")
+        browser.go_to("/ferrum/attributes_properties")
       end
 
       it "gets normalized href" do
@@ -110,9 +110,9 @@ module Ferrum
 
     describe "Node#==" do
       it "does not equal a node from another page" do
-        browser.goto("/ferrum/simple")
+        browser.go_to("/ferrum/simple")
         el1 = browser.at_css("#nav")
-        browser.goto("/ferrum/set")
+        browser.go_to("/ferrum/set")
         el2 = browser.at_css("#filled_div")
         expect(el2 == el1).to be false
         expect(el1 == el2).to be false

--- a/spec/screenshot_spec.rb
+++ b/spec/screenshot_spec.rb
@@ -9,7 +9,7 @@ module Ferrum
     context "screenshot support" do
       shared_examples "screenshot screen" do
         it "supports screenshotting the whole of a page that goes outside the viewport" do
-          browser.goto("/ferrum/long_page")
+          browser.go_to("/ferrum/long_page")
 
           create_screenshot(path: file)
 
@@ -27,7 +27,7 @@ module Ferrum
         end
 
         it "supports screenshotting the entire window when documentElement has no height" do
-          browser.goto("/ferrum/fixed_positioning")
+          browser.go_to("/ferrum/fixed_positioning")
 
           create_screenshot(path: file, full: true)
 
@@ -37,7 +37,7 @@ module Ferrum
         end
 
         it "supports screenshotting just the selected element" do
-          browser.goto("/ferrum/long_page")
+          browser.go_to("/ferrum/long_page")
 
           create_screenshot(path: file, selector: "#penultimate")
 
@@ -54,7 +54,7 @@ module Ferrum
         end
 
         it "ignores :selector in #save_screenshot if full: true" do
-          browser.goto("/ferrum/long_page")
+          browser.go_to("/ferrum/long_page")
           expect(browser.page).to receive(:warn).with(/Ignoring :selector/)
 
           create_screenshot(path: file, full: true, selector: "#penultimate")
@@ -67,7 +67,7 @@ module Ferrum
         end
 
         it "resets element positions after" do
-          browser.goto("ferrum/long_page")
+          browser.go_to("ferrum/long_page")
           el = browser.at_css("#middleish")
           # make the page scroll an element into view
           el.click
@@ -92,7 +92,7 @@ module Ferrum
         end
 
         it "supports screenshotting the page" do
-          browser.goto
+          browser.go_to
 
           browser.screenshot(path: file)
 
@@ -100,7 +100,7 @@ module Ferrum
         end
 
         it "supports screenshotting the page with a nonstring path" do
-          browser.goto
+          browser.go_to
 
           browser.screenshot(path: Pathname(file))
 
@@ -109,7 +109,7 @@ module Ferrum
 
         context "fullscreen" do
           it "supports screenshotting of fullscreen" do
-            browser.goto("/ferrum/custom_html_size")
+            browser.go_to("/ferrum/custom_html_size")
             expect(browser.viewport_size).to eq([1024, 768])
 
             browser.screenshot(path: file, full: true)
@@ -121,7 +121,7 @@ module Ferrum
           end
 
           it "keeps current viewport" do
-            browser.goto
+            browser.go_to
             browser.resize(width: 800, height: 200)
 
             browser.screenshot(path: file, full: true)
@@ -131,7 +131,7 @@ module Ferrum
           end
 
           it "resets to previous viewport when exception is raised" do
-            browser.goto("/ferrum/custom_html_size")
+            browser.go_to("/ferrum/custom_html_size")
             browser.resize(width: 100, height: 100)
 
             allow(browser.page).to receive(:command).and_call_original
@@ -150,7 +150,7 @@ module Ferrum
         it "supports screenshotting the page to file without extension when format is specified" do
           begin
             file = PROJECT_ROOT + "/spec/tmp/screenshot"
-            browser.goto
+            browser.go_to
 
             browser.screenshot(path: file, format: "jpg")
 
@@ -166,7 +166,7 @@ module Ferrum
           FileUtils.rm_f([file2, file3])
 
           begin
-            browser.goto
+            browser.go_to
             browser.screenshot(path: file, quality: 0) # ignored for png
             browser.screenshot(path: file2) # defaults to a quality of 75
             browser.screenshot(path: file3, quality: 100)
@@ -179,7 +179,7 @@ module Ferrum
 
         shared_examples "when scale is set" do
           it "changes image dimensions" do
-            browser.goto("/ferrum/zoom_test")
+            browser.go_to("/ferrum/zoom_test")
 
             black_pixels_count = lambda { |file|
               img = ChunkyPNG::Image.from_file(file)
@@ -208,7 +208,7 @@ module Ferrum
 
         context "when :paper_width and :paper_height are set" do
           it "changes pdf size" do
-            browser.goto("/ferrum/long_page")
+            browser.go_to("/ferrum/long_page")
 
             browser.pdf(path: file, paper_width: 1.0, paper_height: 1.0)
 
@@ -223,7 +223,7 @@ module Ferrum
 
         context "when format is passed" do
           it "changes pdf size to A0" do
-            browser.goto("/ferrum/long_page")
+            browser.go_to("/ferrum/long_page")
 
             browser.pdf(path: file, format: :A0)
 
@@ -236,7 +236,7 @@ module Ferrum
           end
 
           it "specifying format and paperWidth will cause exception" do
-            browser.goto("/ferrum/long_page")
+            browser.go_to("/ferrum/long_page")
 
             expect {
               browser.pdf(path: file, format: :A0, paper_width: 1.0)
@@ -244,7 +244,7 @@ module Ferrum
           end
 
           it "convert case correct" do
-            browser.goto("/ferrum/long_page")
+            browser.go_to("/ferrum/long_page")
 
             allow(browser.page).to receive(:command).with("Page.printToPDF", {
                displayHeaderFooter: false,
@@ -292,7 +292,7 @@ module Ferrum
           end
 
           it "defaults to base64 when path isn't set" do
-            browser.goto
+            browser.go_to
 
             screenshot = browser.screenshot(format: format)
 
@@ -300,7 +300,7 @@ module Ferrum
           end
 
           it "supports screenshotting the page in base64" do
-            browser.goto
+            browser.go_to
 
             screenshot = browser.screenshot(encoding: :base64)
 

--- a/spec/xvfb_spec.rb
+++ b/spec/xvfb_spec.rb
@@ -10,7 +10,7 @@ module Ferrum
 
         it "allows to run tests configured to xvfb" do
           begin
-            xvfb_browser.goto(base_url)
+            xvfb_browser.go_to(base_url)
 
             expect(xvfb_browser.body).to include("Hello world!")
             expect(process_alive?(process.xvfb.pid)).to be(true)
@@ -28,7 +28,7 @@ module Ferrum
 
         it "allows to run tests configured to xvfb" do
           begin
-            xvfb_browser.goto(base_url)
+            xvfb_browser.go_to(base_url)
 
             expect(xvfb_browser.body).to include("Hello world!")
             expect(process_alive?(process.xvfb.pid)).to be(true)
@@ -47,7 +47,7 @@ module Ferrum
 
       it "allows to run tests configured to xvfb" do
         begin
-          xvfb_browser.goto(base_url)
+          xvfb_browser.go_to(base_url)
 
           expect(xvfb_browser.body).to include("Hello world!")
           expect(process_alive?(process.xvfb.pid)).to be(true)


### PR DESCRIPTION
Hi @route,

it's me again. :wave:
I thought that #106 makes sense and thus I gave it a go.
~~I used the inbuilt deprecation method to deprecate `goto` (since it's more Ruby like to use method names with underscore divided words) but I didn't know when you would like to deprecate it?~~
~~I've set it now to April 2021. I mean, of course it isn't a hard date but what date would make sense here?~~

~~This is how it looks like when you call the deprecated name:~~

![NOTE: Ferrum::Page#goto is deprecated; use go_to instead. It will be removed on or after 2021-04-01. Ferrum::Page#goto called from /home/user/.rbenv/versions/2.7.1/lib/ruby/2.7.0/forwardable.rb:235.](https://user-images.githubusercontent.com/372620/97198330-f65d7380-17ae-11eb-9177-167e3729f047.png)

**EDIT:** I removed the deprecation warning now, since deprecating the former name is obviously not wanted.

**PS:** If you're going to merge this: would you be so kind and add the [`hacktoberfest-accepted`](https://hacktoberfest.digitalocean.com/hacktoberfest-update) label to this PR? Thank you in advance!