### PR TITLE
Stream PDFs in chunks instead of copying them whole into memory

### DIFF
--- a/lib/ferrum.rb
+++ b/lib/ferrum.rb
@@ -10,7 +10,10 @@ module Ferrum
   class NotImplementedError < Error; end
 
   class StatusError < Error
+    attr_reader :pendings
+
     def initialize(url, pendings = [])
+      @pendings = pendings
       message = if pendings.empty?
                   "Request to #{url} failed to reach server, check DNS and/or server status"
                 else

--- a/spec/screenshot_spec.rb
+++ b/spec/screenshot_spec.rb
@@ -246,7 +246,7 @@ module Ferrum
           it "convert case correct" do
             browser.goto("/ferrum/long_page")
 
-            allow(browser.page).to receive(:command).with("Page.printToPDF", {
+            allow(browser.page).to receive(:command).with("Page.printToPDF", hash_including(
                displayHeaderFooter: false,
                ignoreInvalidPageRanges: false,
                landscape: false,
@@ -261,8 +261,11 @@ module Ferrum
                preferCSSPageSize: false,
                printBackground: false,
                scale: 1,
-               transferMode: "ReturnAsBase64"
-            }) { { "data" => "" } }
+            )) { { "stream" => "1" } }
+
+            allow(browser.page).to receive(:command).with("IO.read", hash_including(
+              handle: "1"
+            )) { { "data" => "", "base64Encoded" => false, "eof" => true } }
 
             browser.pdf(path: file, landscape: false,
                                     display_header_footer: false,
@@ -276,8 +279,7 @@ module Ferrum
                                     margin_right: 0.4,
                                     page_ranges: "",
                                     ignore_invalid_page_ranges: false,
-                                    prefer_css_page_size: false,
-                                    transfer_mode: "ReturnAsBase64")
+                                    prefer_css_page_size: false)
           end
         end
 


### PR DESCRIPTION
The CDP protocol supports two methods for retrieving the results of `Page.printToPDF` commands:
1. Transfer the whole PDF file in one go over the WebSocket as a response from the `Page.printToPDF` command.
2. Return a "stream handle" from the `Page.printToPDF` command and let the caller transfer the PDF in chunks via subsequent `IO.read` commands.

Method 1, which is currently being used, has several drawbacks when it comes to printing large PDF files:
- The file may be larger than the WebSocket's max receive size. This can be worked around by setting a larger max receive size, but that's an imperfect solution as there's always the chance that we will encounter a larger file.
- Transferring the whole file into memory before storing it into a file causes a memory spike in the Ruby process and its child Chrome processes. Furthermore, while any memory used by the Chrome processes is released after closing the browser, the memory used by the parent Ruby process is never reclaimed by the garbage collector leading to a permanent memory bloat.
- The points above are exacerbated by the fact that Chrome uses Base64 encoding to transfer the PDF over the WebSocket. This means that the transferred data size is further inflated by 33%, and that the PDF contents have to be copied a _second_ time into memory when converting them back to binary.

This PR reimplements `Page#pdf` to use method 2 in order to prevent that memory bloat. Here are some test results measuring memory usage of a Rails app that converts a sample HTML to an 85M PDF file:

- Baseline: after loading the HTML, before calling `Page#pdf`

  ```
  Rails process:      242M
    Chromium parent:   61M
      Chromium child:  94M
      Chromium child:  55M
      Chromium child:  64M
  ```

- Method 1: returning the whole PDF into memory

  ```
  Rails process:      803M
    Chromium parent:  713M
      Chromium child: 404M
      Chromium child:  55M
      Chromium child:  64M
  ```

- Method 2: streaming the PDF into 128K chunks

  ```
  Rails process:      265M
    Chromium parent:  316M
      Chromium child: 405M
      Chromium child:  55M
      Chromium child:  64M
  ```

The chunk size of 128K was chosen because it represented the sweet spot of a large enough chunk and minimal memory usage in tests of various chunk sizes. The results (Rails process memory usage corresponding to a given chink size) were:
```
-   1M: 292M
- 512K: 278M
- 256K: 278M
- 128K: 265M
-  64K: 269M
-  32K: 274M
-  16K: 285M
```