### PR TITLE
Canceled request handling

### DIFF
--- a/lib/ferrum/network.rb
+++ b/lib/ferrum/network.rb
@@ -157,6 +157,14 @@ module Ferrum
         end
       end
 
+      @page.on("Network.loadingFailed") do |params|
+        exchange = select(params["requestId"]).last
+
+        if exchange && params['canceled']
+          exchange.error = :canceled
+        end
+      end
+
       @page.on("Log.entryAdded") do |params|
         entry = params["entry"] || {}
         if entry["source"] == "network" && entry["level"] == "error"

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -67,6 +67,12 @@ module Ferrum
       expect(browser.network.idle?).to be true
     end
 
+    it "captures canceled requests" do
+      browser.go_to("/ferrum/with_ajax_connection_canceled")
+      expect(browser.at_xpath("//h1[text() = 'Canceled']")).to be
+      expect(browser.network.idle?).to be true
+    end
+
     it "keeps a running list between multiple web page views" do
       browser.go_to("/ferrum/with_js")
       expect(traffic.length).to eq(4)

--- a/spec/support/views/with_ajax_connection_canceled.erb
+++ b/spec/support/views/with_ajax_connection_canceled.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <title>ferrum with_js</title>
+    <script src="/ferrum/jquery.min.js" type="text/javascript" charset="utf-8"></script>
+  </head>
+  <body>
+    <h1>Here</h1>
+    <script>
+      $.ajax("http://localhost:12345/slow_response").abort();
+      $("h1").text("Canceled");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This is a proof of concept for fixing #135. The spec fails initially and passes with the second commit.

How do you want to handle this? My initial suggestion would be for a canceled request to be considered as a failed network exchange (CDP's event is called `Network.loadingFailed` after all) and so I could assign a `Network::Error` instance to `exchange.error` but I haven't put much thought into this so I wanted to check first.

All that being said, I also see that errors are currently handled by `Log.entryAdded` instead of `Network.loadingFailed` so maybe there's something I'm missing. Otherwise I wonder if we should handle _all_ `Network.loadingFailed` events (instead of just those where `params['canceled'] == true`).