### PR TITLE
Fix test: resize viewport by fullscreen

### DIFF
--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -104,7 +104,7 @@ module Ferrum
 
       include_examples 'resize viewport by fullscreen' do
         let(:path) { "/ferrum/custom_html_size_100%" }
-        let(:viewport_size) { [1280, 1016] }
+        let(:viewport_size) { [1272, 1008] }
       end
     end
 

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -87,11 +87,25 @@ module Ferrum
       expect(browser.viewport_size).to eq([200, 400])
     end
 
-    it "allows the viewport to be resized by fullscreen" do
-      browser.go_to("/ferrum/custom_html_size")
-      expect(browser.viewport_size).to eq([1024, 768])
-      browser.resize(fullscreen: true)
-      expect(browser.viewport_size).to eq([1280, 1024])
+    context 'fullscreen' do
+      shared_examples 'resize viewport by fullscreen' do
+        it "allows the viewport to be resized by fullscreen" do
+          expect(browser.viewport_size).to eq([1024, 768])
+          browser.go_to(path)
+          browser.resize(fullscreen: true)
+          expect(browser.viewport_size).to eq(viewport_size)
+        end
+      end
+
+      include_examples 'resize viewport by fullscreen' do
+        let(:path) { "/ferrum/custom_html_size" }
+        let(:viewport_size) { [1280, 1024] }
+      end
+
+      include_examples 'resize viewport by fullscreen' do
+        let(:path) { "/ferrum/custom_html_size_100%" }
+        let(:viewport_size) { [1280, 1016] }
+      end
     end
 
     it "allows the page to be scrolled" do

--- a/spec/support/views/custom_html_size.erb
+++ b/spec/support/views/custom_html_size.erb
@@ -3,17 +3,11 @@
     <title>custom_size</title>
     <style>
       html {
-        width: 100%;
-        height: 100%;
-      }
-
-      .spacer {
-        width:  1272px; /* using scrollWidth  adds 8px */
-        height: 1008px; /* using scrollHeight adds 16px */
+        width: 1280px;
+        height: 1024px;
       }
     </style>
   </head>
   <body>
-    <div class="spacer"></div>
   </body>
 </html>

--- a/spec/support/views/custom_html_size_100%.erb
+++ b/spec/support/views/custom_html_size_100%.erb
@@ -7,9 +7,17 @@
         height: 100%;
       }
 
+      body {
+        /*
+          deal with the default Chrome margins
+          https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/html/resources/html.css;
+        */
+        margin: 0;
+      }
+
       .spacer {
-        width:  1272px; /* using scrollWidth  adds 8px */
-        height: 1008px; /* using scrollHeight adds 16px */
+        width:  1272px;
+        height: 1008px;
       }
     </style>
   </head>

--- a/spec/support/views/custom_html_size_100%.erb
+++ b/spec/support/views/custom_html_size_100%.erb
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <title>custom_size</title>
+    <style>
+      html {
+        width: 100%;
+        height: 100%;
+      }
+
+      .spacer {
+        width:  1272px; /* using scrollWidth  adds 8px */
+        height: 1008px; /* using scrollHeight adds 16px */
+      }
+    </style>
+  </head>
+  <body>
+    <div class="spacer"></div>
+  </body>
+</html>


### PR DESCRIPTION
We have 2 things here:
1) The test `allows the viewport to be resized by fullscreen` with specified explicitly `width/height` is green for both cases: offsetWidth and scrollWidth
HTML:
```
<html>
  <head>
    <title>custom_size</title>
    <style>
      html {
        width: 1280px;
        height: 1024px;
      }
    </style>
  </head>
  <body>
  </body>
</html>
```
Green:
```
      def document_size
        evaluate <<~JS
          [document.documentElement.offsetWidth,
           document.documentElement.offsetHeight]
        JS
      end
```
Green:
```
      def document_size
        evaluate <<~JS
          [document.documentElement.scrollWidth,
           document.documentElement.scrollHeight]
        JS
      end
```

so, I think, we should keep test with this HTML.

2) The second case was described here: https://github.com/rubycdp/ferrum/pull/51

I think, it's better to use the dedicated file with HTML for `width: 100%; / height: 100%;`:

So, test failed:
```
expected: [1280, 1024]
            got: [1280, 1016]
```

because of default Chrome css margins:
https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/html/resources/html.css;l=57-60

Which was added, I guess, in `72.0.3626.0` version:
https://source.chromium.org/chromium/chromium/src/+/refs/tags/72.0.3626.0:third_party/blink/renderer/core/html/resources/html.css
Source

https://source.chromium.org/chromium/chromium/src/+/refs/tags/72.0.3625.2:third_party/blink/renderer/core/html/resources/html.css
No source for the previous version.

We also, can confirm it here: https://browserdefaultstyles.com/
![Selection_046](https://user-images.githubusercontent.com/23525618/105183631-3cc53300-5b50-11eb-9f94-a8ea04799d13.jpg)

So, the correct values for this test, should be:
![Selection_045](https://user-images.githubusercontent.com/23525618/105183765-61210f80-5b50-11eb-9f58-95ccfc1e890c.jpg)
