### PR TITLE
Specify slowmo as delay in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Ferrum::Browser.new(options)
       `["/path/to/script.js", { source: "window.secret = 'top'" }]`
   * `:logger` (Object responding to `puts`) - When present, debug output is
       written to this object.
-  * `:slowmo` (Integer | Float) - Set a delay to wait before sending command.
+  * `:slowmo` (Integer | Float) - Set a delay in seconds to wait before sending command.
       Usefull companion of headless option, so that you have time to see changes.
   * `:timeout` (Numeric) - The number of seconds we'll wait for a response when
       communicating with browser. Default is 5.


### PR DESCRIPTION
I went digging into the source to find if this was in seconds or ms since Puppeteer is always in ms. I felt it should just be added to the readme saving people the future dig.