### PR TITLE
fix intermittent test failures of 'resizes windows' test

### DIFF
--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -423,10 +423,10 @@ module Ferrum
 
       expect(browser.targets.size).to eq(1)
 
-      browser.execute <<-JS
+      browser.evaluate <<-JS
         window.open("/ferrum/simple", "popup1")
       JS
-      browser.execute <<-JS
+      browser.evaluate <<-JS
         window.open("/ferrum/simple", "popup2")
       JS
 


### PR DESCRIPTION
Fix intermittent test failures:
```
Failures:

  1) Ferrum::Browser resizes windows
     Failure/Error: popup2.resize(width: 200, height: 100)
     
     NoMethodError:
       undefined method `resize' for nil:NilClass
     # ./spec/browser_spec.rb:435:in `block (2 levels) in <module:Ferrum>'

Finished in 19.95 seconds (files took 1.15 seconds to load)
18 examples, 1 failure, 1 pending

Failed examples:

rspec ./spec/browser_spec.rb:421 # Ferrum::Browser resizes windows
```
https://app.circleci.com/pipelines/github/rubycdp/ferrum/53/workflows/2891ea2c-78d4-443c-87b3-4f31ad62e917/jobs/382