### PR TITLE
fix spelling error: PAPEP_FORMATS => PAPER_FORMATS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 - `Ferrum::Page::Screenshot::DEFAULT_PDF_OPTIONS` - pdf settings constant
 
-- `Ferrum::Page::Screenshot::PAPEP_FORMATS` - available formats constant
+- `Ferrum::Page::Screenshot::PAPER_FORMATS` - available formats constant
 
 - `Ferrum::Page::Frames` module implementation:
 

--- a/lib/ferrum/page/screenshot.rb
+++ b/lib/ferrum/page/screenshot.rb
@@ -12,7 +12,7 @@ module Ferrum
         scale: 1.0
       }.freeze
 
-      PAPEP_FORMATS = {
+      PAPER_FORMATS = {
         letter:   { width:  8.50, height: 11.00 },
         legal:    { width:  8.50, height: 14.00 },
         tabloid:  { width: 11.00, height: 17.00 },
@@ -114,7 +114,7 @@ module Ferrum
             raise ArgumentError, "Specify :format or :paper_width, :paper_height"
           end
 
-          dimension = PAPEP_FORMATS.fetch(format)
+          dimension = PAPER_FORMATS.fetch(format)
           options.merge!(paper_width: dimension[:width],
                          paper_height: dimension[:height])
         end


### PR DESCRIPTION
![Did you mean: PAPER_FORMATS ](https://user-images.githubusercontent.com/372620/109430422-b67af700-7a01-11eb-8954-7415a9f53ebe.png)

related to PR https://github.com/rubycdp/ferrum/pull/12

As always: thank you for your work and [never give up](https://twitter.com/alexanderadam__/status/1362818462557622272) :wink: 