### PR TITLE
Capture error stacktraces

### DIFF
--- a/lib/ferrum.rb
+++ b/lib/ferrum.rb
@@ -103,10 +103,11 @@ module Ferrum
   end
 
   class JavaScriptError < BrowserError
-    attr_reader :class_name, :message
+    attr_reader :class_name, :message, :stack_trace
 
-    def initialize(response)
+    def initialize(response, stack_trace = nil)
       @class_name, @message = response.values_at("className", "description")
+      @stack_trace = stack_trace
       super(response.merge("message" => @message))
     end
   end

--- a/lib/ferrum/frame/runtime.rb
+++ b/lib/ferrum/frame/runtime.rb
@@ -154,7 +154,7 @@ module Ferrum
         when /\AError: timed out promise/
           raise ScriptTimeoutError
         else
-          raise JavaScriptError.new(result)
+          raise JavaScriptError.new(result, response.dig("exceptionDetails", "stackTrace"))
         end
       end
 

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -221,7 +221,10 @@ module Ferrum
       if @browser.js_errors
         on("Runtime.exceptionThrown") do |params|
           # FIXME https://jvns.ca/blog/2015/11/27/why-rubys-timeout-is-dangerous-and-thread-dot-raise-is-terrifying/
-          Thread.main.raise JavaScriptError.new(params.dig("exceptionDetails", "exception"))
+          Thread.main.raise JavaScriptError.new(
+            params.dig("exceptionDetails", "exception"),
+            params.dig("exceptionDetails", "stackTrace")
+          )
         end
       end
 


### PR DESCRIPTION
Ferrum loses some bit of information about JS errors thrown. This PR restores stacktraces.