### PR TITLE
Simplify Proxy Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,14 +577,14 @@ while your code denies but it's too late. The block is mandatory now.
 You can set a proxy with the `proxy` option.
 
 ```ruby
-browser = Ferrum::Browser.new(proxy: {server: {host: "x.x.x.x", port: "8800" }})
-browser = Ferrum::Browser.new(proxy: {server: {host: "x.x.x.x", port: "8800", user: "user", pasword: "pa$$" }})
+browser = Ferrum::Browser.new(proxy: {host: "x.x.x.x", port: "8800" })
+browser = Ferrum::Browser.new(proxy: {host: "x.x.x.x", port: "8800", user: "user", pasword: "pa$$" })
 ```
 
 Chrome Devtools Protocol does not support changing proxies after the browser is launched. If you want to change proxies, you must restart your browser, which may not be convenient. There is a workaround. Ferrum provides a wrapper for a proxy server that can rotate proxies. We can run a proxy in the same process and rotate proxies inside this proxy server:
 
 ```ruby
-browser = Ferrum::Browser.new(proxy: { server: { run: true } })
+browser = Ferrum::Browser.new(proxy: { server: true })
 
 browser.proxy_server.rotate(host: "x.x.x.x", port: 31337, user: "user", password: "password")
 browser.create_page(new_context: true) do |page|
@@ -605,7 +605,8 @@ requests even if you close the page.
 You can specify semi-colon-separated list of hosts for which proxy shouldn't be used:
 
 ```ruby
-browser = Ferrum::Browser.new(proxy: { server: { run: true }, bypass: "*.google.com;*foo.com" })
+browser = Ferrum::Browser.new(proxy: {host: "x.x.x.x", port: "8800", bypass: "*.google.com;*foo.com" })
+browser = Ferrum::Browser.new(proxy: {server: true, bypass: "*.google.com;*foo.com" })
 ```
 
 

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -49,15 +49,16 @@ module Ferrum
       @js_errors = @options.fetch(:js_errors, false)
 
       if @options[:proxy]
-        bypass, @proxy_options = @options[:proxy].values_at(:bypass, :server)
+        @proxy_options = @options[:proxy]
 
-        if @proxy_options[:run]
+        if @proxy_options[:server]
           @proxy_server = Proxy.start(**@proxy_options.slice(:host, :port, :user, :password))
           @proxy_options.merge!(host: @proxy_server.host, port: @proxy_server.port)
         end
 
         @options[:browser_options] ||= {}
         address = "#{@proxy_options[:host]}:#{@proxy_options[:port]}"
+        bypass = @proxy_options[:bypass]
         @options[:browser_options].merge!("proxy-server" => address)
         @options[:browser_options].merge!("proxy-bypass-list" => bypass) if bypass
       end

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -368,7 +368,7 @@ module Ferrum
         it "works without authorization" do
           begin
             browser = Ferrum::Browser.new(
-              proxy: { server: { host: proxy.host, port: proxy.port } }
+              proxy: { host: proxy.host, port: proxy.port }
             )
 
             browser.go_to("https://example.com")
@@ -386,7 +386,7 @@ module Ferrum
         it "works with right password" do
           begin
             browser = Ferrum::Browser.new(
-              proxy: { server: { host: proxy.host, port: proxy.port, **options } }
+              proxy: { host: proxy.host, port: proxy.port, **options }
             )
 
             browser.go_to("https://example.com")
@@ -400,7 +400,7 @@ module Ferrum
         it "breaks with wrong password" do
           begin
             browser = Ferrum::Browser.new(
-              proxy: { server: { host: proxy.host, port: proxy.port, user: "u1", password: "p1" } }
+              proxy: { host: proxy.host, port: proxy.port, user: "u1", password: "p1" }
             )
 
             browser.go_to("https://example.com")
@@ -415,7 +415,7 @@ module Ferrum
         it "works after disposing context" do
           begin
             browser = Ferrum::Browser.new(
-              proxy: { server: { run: true } }
+              proxy: { server: true }
             )
 
             browser.proxy_server.rotate(host: "host", port: 0, user: "user", password: "password")


### PR DESCRIPTION
This change flattens the `:proxy` option as discussed at https://github.com/rubycdp/ferrum/pull/207#issuecomment-948041330