### PR TITLE
Add `Ferrum::Node#computed_style`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ a block with this page, after which the page is closed.
 - `Ferrum::Node`
   - `#selected` check selected option
   - `#select` select option
+  - `#computed_style` returns hash of computed styles
 - `Ferrum::JavaScriptError#stack_trace` attr_reader
 - Windows support
 - Show warning and accept dialog if no handler given

--- a/lib/ferrum/node.rb
+++ b/lib/ferrum/node.rb
@@ -193,6 +193,13 @@ module Ferrum
       [x, y]
     end
 
+    # Returns a hash of the computed styles for the node
+    def computed_style
+      page
+        .command("CSS.getComputedStyleForNode", nodeId: node_id)["computedStyle"]
+        .inject({}) { |memo, style| memo[style["name"]] = style["value"]; memo }
+    end
+
     private
 
     def bounding_rect_coordinates

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -259,5 +259,18 @@ module Ferrum
         it { expect(browser.at_css("#form_name").focusable?).to eq(true) }
       end
     end
+
+    describe "#computed_style" do
+      before do
+        browser.go_to("/ferrum/computed_style")
+      end
+
+      it "returns the computed styles for the node" do
+        styles = browser.at_css("#test_node").computed_style
+
+        expect(styles["color"]).to eq("rgb(255, 0, 0)")
+        expect(styles["font-weight"]).to eq("700")
+      end
+    end
   end
 end

--- a/spec/support/views/computed_style.erb
+++ b/spec/support/views/computed_style.erb
@@ -1,0 +1,6 @@
+<style>
+.foo { color: red; }
+.bar { font-weight: bold; }
+</style>
+
+<span id="test_node" class="foo bar">Test</span>


### PR DESCRIPTION
This PR adds `Ferrum::Node#computed_style`, providing an API for seeing what CSS styles are applied to a node. 