### PR TITLE
run 'bundle exec rubocop -A' to fix latest master build

### DIFF
--- a/lib/ferrum/cookies.rb
+++ b/lib/ferrum/cookies.rb
@@ -54,7 +54,7 @@ module Ferrum
 
     def all
       cookies = @page.command("Network.getAllCookies")["cookies"]
-      cookies.map { |c| [c["name"], Cookie.new(c)] }.to_h
+      cookies.to_h { |c| [c["name"], Cookie.new(c)] }
     end
 
     def [](name)

--- a/lib/ferrum/page/screenshot.rb
+++ b/lib/ferrum/page/screenshot.rb
@@ -75,7 +75,7 @@ module Ferrum
       def save_file(path, data)
         return data unless path
 
-        File.open(path.to_s, "wb") { |f| f.write(data) }
+        File.binwrite(path.to_s, data)
       end
 
       def stream_to_file(handle, path:)

--- a/spec/keyboard_spec.rb
+++ b/spec/keyboard_spec.rb
@@ -305,7 +305,7 @@ module Ferrum
 
       it "attaches a file when passed a Pathname", skip: true do
         filename = Pathname.new("spec/tmp/a_test_pathname").expand_path
-        File.open(filename, "w") { |f| f.write("text") }
+        File.write(filename, "text")
 
         element = browser.at_css("#change_me_file")
         element.set(filename)

--- a/spec/screenshot_spec.rb
+++ b/spec/screenshot_spec.rb
@@ -235,7 +235,7 @@ module Ferrum
 
           def create_screenshot(path:, **options)
             image = browser.screenshot(format: format, encoding: :base64, **options)
-            File.open(path, "wb") { |f| f.write Base64.decode64(image) }
+            File.binwrite(path, Base64.decode64(image))
           end
 
           it "defaults to base64 when path isn't set" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |config|
 
   def save_exception_log(_browser, filename, line_number, timestamp, ferrum_logger)
     log_name = "logfile-#{filename}-#{line_number}-#{timestamp}.txt"
-    File.open("/tmp/ferrum/#{log_name}", "wb") { |file| file.write(ferrum_logger.string) }
+    File.binwrite("/tmp/ferrum/#{log_name}", ferrum_logger.string)
   rescue StandardError => e
     puts "#{e.class}: #{e.message}"
   end


### PR DESCRIPTION
https://github.com/rubycdp/ferrum/runs/4734010373?check_suite_focus=true
caused by updated rubocop:
`rubocop 1.26.1 (was 1.22.3)`