### PR TITLE
Add postData getter for network request

### DIFF
--- a/lib/ferrum/network/request.rb
+++ b/lib/ferrum/network/request.rb
@@ -49,6 +49,7 @@ module Ferrum
       def post_data
         @request["postData"]
       end
+      alias body post_data
     end
   end
 end

--- a/lib/ferrum/network/request.rb
+++ b/lib/ferrum/network/request.rb
@@ -45,6 +45,10 @@ module Ferrum
       def time
         @time ||= Time.strptime(@params["wallTime"].to_s, "%s")
       end
+
+      def post_data
+        @request["postData"]
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is to add a method on the `Ferrum::Network::Request` object in order to allow the optional POST body to be retrieved (or `nil` when it does not exist).

It looks like unit tests are skipped for this object, but let me know if this requires additional changes in order to be merged. 
