### PR TITLE
Add a simple download spec and mention save_path in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Ferrum::Browser.new(options)
       over the web socket, in bytes. Defaults to 64MB. Incoming messages larger
       than this will cause a `Ferrum::DeadBrowserError`.
   * `:proxy` (Hash) - Specify proxy settings, [read more](https://github.com/rubycdp/ferrum#proxy)
+  * `:save_path` (String) - Path to save screenshots, PDF, mhtml, and attachment requests
 
 
 ## Navigation

--- a/spec/download_spec.rb
+++ b/spec/download_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Ferrum
+  describe Browser do
+    context "download support" do
+      let(:browser) do
+        Ferrum::Browser.new(
+          base_url: Ferrum::Server.server.base_url,
+          save_path: "/tmp/ferrum"
+        )
+      end
+
+      it "saves an attachment" do
+        browser.go_to("/attachment.pdf")
+
+        expect(File.exist?("/tmp/ferrum/attachment.pdf")).to be true
+      end
+    end
+  end
+end

--- a/spec/support/application.rb
+++ b/spec/support/application.rb
@@ -182,6 +182,12 @@ module Ferrum
       "This, is, comma, separated"
     end
 
+    get "/attachment.pdf" do
+      path = "/tmp/ferrum/attachment.pdf"
+      FileUtils.touch(path)
+      attachment(path, :attachment)
+    end
+
     get "/:view" do |view|
       erb view.to_sym, locals: { referrer: request.referrer }
     end


### PR DESCRIPTION
For #169 and to add `save_path` to the readme. 