### PR TITLE
Page.setDownloadBehavior is deprecated, replace with Browser.setDownloadBehavior

### DIFF
--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -262,7 +262,7 @@ module Ferrum
       end
 
       if @browser.options[:save_path]
-        command("Page.setDownloadBehavior", behavior: "allow", downloadPath: @browser.options[:save_path])
+        command("Browser.setDownloadBehavior", behavior: "allow", downloadPath: @browser.options[:save_path], eventsEnabled: true)
       end
 
       @browser.extensions.each do |extension|


### PR DESCRIPTION
As mentioned here:

- https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-setDownloadBehavior
- https://github.com/ChromeDevTools/devtools-protocol/issues/242

Docs for [`Browser.setDownloadBehavior`](https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-setDownloadBehavior).

I set `eventsEnabled` to true which emits additional `Browser.downloadProgress` events, I'd imagine they'll eventually remove the `Page.downloadProgress` events but I can disable that setting if it's too noisy.

```
    ◀ 3.2597489999607205 {"method":"Browser.downloadWillBegin","params":{"frameId":"34A75E1135DB6FB92E741C517C2BF03B","guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","url":"https://codeload.github.com/rubycdp/ferrum/zip/refs/tags/v0.11","suggestedFilename":"ferrum-0.11.zip"}}
    ◀ 3.2601709999144077 {"method":"Page.downloadWillBegin","params":{"frameId":"34A75E1135DB6FB92E741C517C2BF03B","guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","url":"https://codeload.github.com/rubycdp/ferrum/zip/refs/tags/v0.11","suggestedFilename":"ferrum-0.11.zip"}}
    ◀ 3.262694999924861 {"method":"Browser.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":0,"state":"inProgress"}}
    ◀ 3.2628339999355376 {"method":"Page.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":0,"state":"inProgress"}}
    ◀ 3.2657559999497607 {"method":"Browser.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":0,"state":"inProgress"}}
    ◀ 3.2659559999592602 {"method":"Page.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":0,"state":"inProgress"}}
    ◀ 3.489164999919012 {"method":"Browser.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":257051,"state":"inProgress"}}
    ◀ 3.490538000012748 {"method":"Page.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":257051,"state":"inProgress"}}
    ◀ 3.490605999948457 {"method":"Browser.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":257051,"state":"inProgress"}}
    ◀ 3.49076099996455 {"method":"Page.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":257051,"state":"inProgress"}}
    ◀ 3.491488999919966 {"method":"Browser.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":257051,"state":"inProgress"}}
    ◀ 3.4915329999057576 {"method":"Page.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":257051,"state":"inProgress"}}
    ◀ 3.4924020000034943 {"method":"Browser.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":257051,"state":"completed"}}
    ◀ 3.4930229999590665 {"method":"Page.downloadProgress","params":{"guid":"ec5cdafb-a9dc-406a-a5e1-e5dbb6358684","totalBytes":257051,"receivedBytes":257051,"state":"completed"}}
```