### PR TITLE
Improving the flow of retrieving and setting Cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,18 @@ Sets given values as cookie
 browser.cookies.set(name: "stealth", value: "omg", domain: "google.com") # => true
 ```
 
+#### set(cookie) : `Boolean`
+
+Sets given cookie
+
+* cookie `Cookie`
+
+```ruby
+nid_cookie = browser.cookies["NID"] # => <Ferrum::Cookies::Cookie:0x0000558624b67a88>
+
+browser.cookies.set(nid_cookie) # => true
+```
+
 #### remove(\*\*options) : `Boolean`
 
 Removes given cookie

--- a/lib/ferrum/cookies.rb
+++ b/lib/ferrum/cookies.rb
@@ -3,6 +3,8 @@
 module Ferrum
   class Cookies
     class Cookie
+      attr_reader :attributes
+
       def initialize(attributes)
         @attributes = attributes
       end
@@ -61,10 +63,11 @@ module Ferrum
       all[name]
     end
 
-    def set(name: nil, value: nil, **options)
-      cookie = options.dup
-      cookie[:name]   ||= name
-      cookie[:value]  ||= value
+    def set(options)
+      cookie = (
+        options.is_a?(Cookie) ? options.attributes : options
+      ).dup.transform_keys(&:to_sym)
+
       cookie[:domain] ||= default_domain
 
       cookie[:httpOnly] = cookie.delete(:httponly) if cookie.key?(:httponly)

--- a/spec/cookies_spec.rb
+++ b/spec/cookies_spec.rb
@@ -56,6 +56,110 @@ module Ferrum
         expect(browser.body).to_not include("test_cookie")
       end
 
+      it "can set a retrieved cookie" do
+        browser.cookies.set(name: "stealth", value: "omg")
+
+        browser.go_to("/get_cookie")
+
+        expect(browser.body).to include("omg")
+
+        cookie = browser.cookies.all.values.first
+
+        browser.cookies.clear
+
+        browser.go_to("/get_cookie")
+
+        expect(browser.body).to_not include("omg")
+
+        browser.cookies.set(cookie)
+
+        browser.go_to("/get_cookie")
+
+        expect(browser.body).to include("omg")
+      end
+
+      it "can set a retrieved browser cookie" do
+        browser.go_to("/set_cookie")
+
+        cookie = browser.cookies["stealth"]
+
+        expect(cookie.name).to eq("stealth")
+        expect(cookie.value).to eq("test_cookie")
+
+        browser.go_to("/get_cookie")
+
+        expect(browser.body).to include("test_cookie")
+
+        browser.cookies.clear
+
+        browser.go_to("/get_cookie")
+
+        expect(browser.body).not_to include("test_cookie")
+
+        browser.cookies.set(cookie)
+
+        browser.go_to("/get_cookie")
+
+        expect(browser.body).to include("test_cookie")
+      end
+
+      it "it retains the characteristics of the reference cookie" do
+        browser.cookies.set(name: "stealth", value: "omg", domain: "site.com")
+
+        expect(browser.cookies["stealth"].name).to eq("stealth")
+        expect(browser.cookies["stealth"].value).to eq("omg")
+        expect(browser.cookies["stealth"].domain).to eq("site.com")
+
+        cookie = browser.cookies["stealth"]
+
+        browser.cookies.clear
+
+        expect(browser.cookies["stealth"]).to eq(nil)
+
+        browser.cookies.set(cookie)
+
+        expect(browser.cookies["stealth"].name).to eq("stealth")
+        expect(browser.cookies["stealth"].value).to eq("omg")
+        expect(browser.cookies["stealth"].domain).to eq("site.com")
+
+        browser.cookies.clear
+
+        expect(browser.cookies["stealth"]).to eq(nil)
+
+        browser.cookies.set(cookie.attributes)
+
+        expect(browser.cookies["stealth"].name).to eq("stealth")
+        expect(browser.cookies["stealth"].value).to eq("omg")
+        expect(browser.cookies["stealth"].domain).to eq("site.com")
+      end
+
+      it "it prevents side effects for params" do
+        cookie_params = { name: "stealth", value: "test_cookie" }
+
+        original_cookie_params = cookie_params.dup
+
+        browser.cookies.set(cookie_params)
+
+        expect(cookie_params).to eq(original_cookie_params)
+      end
+
+      it "it prevents side effects for cookie object" do
+        browser.cookies.set(name: "stealth", value: "omg")
+
+        cookie = browser.cookies["stealth"]
+
+        cookie.instance_variable_set(
+          :@attributes,
+          { "name" => "stealth", "value" => "test_cookie", "domain" => "site.com" }
+        )
+
+        original_attributes = cookie.attributes.dup
+
+        browser.cookies.set(cookie)
+
+        expect(cookie.attributes).to eq(original_attributes)
+      end
+
       it "can clear cookies" do
         browser.go_to("/set_cookie")
 


### PR DESCRIPTION
Related to:
- #253 

Allows `browser.cookies.set` to receive either a hash for setting a new cookie or a previously retrieved cookie.