### PR TITLE
Improving browser options semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ browser.quit
 In docker as root you must pass the no-sandbox browser option:
 
 ```ruby
-Ferrum::Browser.new(browser_options: { 'no-sandbox': nil })
+Ferrum::Browser.new(browser_options: { 'no-sandbox': true })
 ```
 
 
@@ -166,7 +166,7 @@ Ferrum::Browser.new(options)
       variable as `BROWSER_PATH=some/path/chrome bundle exec rspec`.
   * `:browser_options` (Hash) - Additional command line options,
       [see them all](https://peter.sh/experiments/chromium-command-line-switches/)
-      e.g. `{ "ignore-certificate-errors" => nil }`
+      e.g. `{ "ignore-certificate-errors" => true }`
   * `:ignore_default_browser_options` (Boolean) - Ferrum has a number of default
       options it passes to the browser, if you set this to `true` then only
       options you put in `:browser_options` will be passed to the browser,

--- a/lib/ferrum/browser/command.rb
+++ b/lib/ferrum/browser/command.rb
@@ -40,7 +40,9 @@ module Ferrum
       end
 
       def to_a
-        [path] + @flags.map { |k, v| v.nil? ? "--#{k}" : "--#{k}=#{v}" }
+        [path] + @flags.reject { |_, v| v.nil? || v == false }.map do |key, value|
+          value == true ? "--#{key}" : "--#{key}=#{value}"
+        end
       end
 
       private

--- a/lib/ferrum/browser/options/base.rb
+++ b/lib/ferrum/browser/options/base.rb
@@ -35,6 +35,19 @@ module Ferrum
           end
         end
 
+        def ensure_required!(options, required_options)
+          return if options[:browser_options].nil?
+
+          required_options.each do |required|
+            next unless options[:browser_options].key?(required)
+
+            if options[:browser_options][required] == false ||
+               options[:browser_options][required].nil?
+              raise ArgumentError, "#{required} is required"
+            end
+          end
+        end
+
         def merge_required(flags, options, user_data_dir)
           raise NotImplementedError
         end

--- a/lib/ferrum/browser/options/chrome.rb
+++ b/lib/ferrum/browser/options/chrome.rb
@@ -5,41 +5,41 @@ module Ferrum
     module Options
       class Chrome < Base
         DEFAULT_OPTIONS = {
-          "headless" => nil,
-          "disable-gpu" => nil,
-          "hide-scrollbars" => nil,
-          "mute-audio" => nil,
-          "enable-automation" => nil,
-          "disable-web-security" => nil,
-          "disable-session-crashed-bubble" => nil,
-          "disable-breakpad" => nil,
-          "disable-sync" => nil,
-          "no-first-run" => nil,
-          "use-mock-keychain" => nil,
-          "keep-alive-for-test" => nil,
-          "disable-popup-blocking" => nil,
-          "disable-extensions" => nil,
-          "disable-hang-monitor" => nil,
+          "headless" => true,
+          "disable-gpu" => true,
+          "hide-scrollbars" => true,
+          "mute-audio" => true,
+          "enable-automation" => true,
+          "disable-web-security" => true,
+          "disable-session-crashed-bubble" => true,
+          "disable-breakpad" => true,
+          "disable-sync" => true,
+          "no-first-run" => true,
+          "use-mock-keychain" => true,
+          "keep-alive-for-test" => true,
+          "disable-popup-blocking" => true,
+          "disable-extensions" => true,
+          "disable-hang-monitor" => true,
           "disable-features" => "site-per-process,TranslateUI",
-          "disable-translate" => nil,
-          "disable-background-networking" => nil,
+          "disable-translate" => true,
+          "disable-background-networking" => true,
           "enable-features" => "NetworkService,NetworkServiceInProcess",
-          "disable-background-timer-throttling" => nil,
-          "disable-backgrounding-occluded-windows" => nil,
-          "disable-client-side-phishing-detection" => nil,
-          "disable-default-apps" => nil,
-          "disable-dev-shm-usage" => nil,
-          "disable-ipc-flooding-protection" => nil,
-          "disable-prompt-on-repost" => nil,
-          "disable-renderer-backgrounding" => nil,
+          "disable-background-timer-throttling" => true,
+          "disable-backgrounding-occluded-windows" => true,
+          "disable-client-side-phishing-detection" => true,
+          "disable-default-apps" => true,
+          "disable-dev-shm-usage" => true,
+          "disable-ipc-flooding-protection" => true,
+          "disable-prompt-on-repost" => true,
+          "disable-renderer-backgrounding" => true,
           "force-color-profile" => "srgb",
-          "metrics-recording-only" => nil,
-          "safebrowsing-disable-auto-update" => nil,
+          "metrics-recording-only" => true,
+          "safebrowsing-disable-auto-update" => true,
           "password-store" => "basic",
-          "no-startup-window" => nil
+          "no-startup-window" => true
           # NOTE: --no-sandbox is not needed if you properly setup a user in the container.
           # https://github.com/ebidel/lighthouse-ci/blob/master/builder/Dockerfile#L35-L40
-          # "no-sandbox" => nil,
+          # "no-sandbox" => true,
         }.freeze
 
         MAC_BIN_PATH = [
@@ -64,6 +64,12 @@ module Ferrum
         end
 
         def merge_default(flags, options)
+          ensure_required!(
+            options,
+            %w[remote-debugging-port remote-debugging-address
+               window-size user-data-dir]
+          )
+
           defaults = except("headless", "disable-gpu") unless options.fetch(:headless, true)
 
           defaults ||= DEFAULT_OPTIONS

--- a/lib/ferrum/browser/options/firefox.rb
+++ b/lib/ferrum/browser/options/firefox.rb
@@ -5,7 +5,7 @@ module Ferrum
     module Options
       class Firefox < Base
         DEFAULT_OPTIONS = {
-          "headless" => nil
+          "headless" => true
         }.freeze
 
         MAC_BIN_PATH = [
@@ -25,6 +25,8 @@ module Ferrum
         end
 
         def merge_default(flags, options)
+          ensure_required!(options, %w[remote-debugger profile])
+
           defaults = except("headless") unless options.fetch(:headless, true)
 
           defaults ||= DEFAULT_OPTIONS

--- a/spec/browser/command_spec.rb
+++ b/spec/browser/command_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Ferrum
+  class Browser
+    describe Command do
+      it "merges default options" do
+        expect(Command.build({}, nil).to_a).to include("--headless")
+        expect(Command.build({}, nil).to_a).to include("--disable-web-security")
+        expect(Command.build({}, nil).to_a).to include("--remote-debugging-port=0")
+
+        expect(
+          Command.build(
+            Browser.new(browser_options: { "disable-web-security" => false }).options,
+            nil
+          ).to_a
+        ).to_not include("--disable-web-security")
+
+        expect(
+          Command.build(
+            Browser.new(browser_options: { "disable-web-security" => nil }).options,
+            nil
+          ).to_a
+        ).to_not include("--disable-web-security")
+
+        expect(
+          Command.build(
+            Browser.new(
+              ignore_default_browser_options: true,
+              browser_options: { "headless" => true }
+            ).options,
+            nil
+          ).to_a
+        ).to include("--remote-debugging-port=0")
+
+        expect(
+          Command.build(
+            Browser.new(
+              ignore_default_browser_options: true,
+              browser_options: { "headless" => true }
+            ).options,
+            nil
+          ).to_a
+        ).not_to include("--enable-automation")
+      end
+    end
+  end
+end

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -42,9 +42,37 @@ module Ferrum
     it "ignores default options" do
       defaults = Browser::Options::Chrome.options.except("disable-web-security")
       browser = Browser.new(ignore_default_browser_options: true, browser_options: defaults)
+
+      expect(browser.options[:browser_options]["disable-web-security"]).to eq(nil)
       browser.go_to(base_url("/ferrum/console_log"))
     ensure
       browser&.quit
+    end
+
+    it "allows options removal" do
+      browser = Browser.new(browser_options: { "disable-web-security" => false })
+
+      expect(browser.options[:browser_options]["disable-web-security"]).to eq(false)
+
+      browser.go_to(base_url("/ferrum/console_log"))
+    ensure
+      browser&.quit
+    end
+
+    it "prevents required flags from being removed" do
+      expect do
+        Browser.new(browser_options: { "remote-debugging-port" => false }).options
+      end.to raise_error(
+        an_instance_of(ArgumentError),
+        "remote-debugging-port is required"
+      )
+
+      expect do
+        Browser.new(browser_options: { "remote-debugging-port" => nil }).options
+      end.to raise_error(
+        an_instance_of(ArgumentError),
+        "remote-debugging-port is required"
+      )
     end
 
     it "raises an error when browser is too slow" do


### PR DESCRIPTION
Today, to set a browser option, you need to:

```ruby
Ferrum::Browser.new(browser_options: { 'no-sandbox': nil })
```

This semantics can be misleading because, at least from my perspective, `nil` is associated with "absence."

It may also mislead people into trying to remove a default option by setting it as `nil`:

```ruby
Ferrum::Browser.new(browser_options: { 'disable-extensions': nil })
```

This PR proposes the use of `true` for desired flags:

```ruby
Ferrum::Browser.new(browser_options: { 'no-sandbox': true })
```

And the use of `nil` or `false` to allow the possibility of easily removing a default option:

```ruby
Ferrum::Browser.new(browser_options: { 'disable-extensions': false })
Ferrum::Browser.new(browser_options: { 'disable-extensions': nil })
```

There's also protection to prevent people from removing required flags:
```ruby
Ferrum::Browser.new(browser_options: { 'remote-debugging-port' => nil })
# => #<ArgumentError: remote-debugging-port is required>
```

I choose an explicit error if the person explicitly tries to remove a required flag rather than just overriding it with the required value. It could confuse the person not understanding why the removal didn't work.

Also, README was updated to instruct the new semantics.

**Overall**

Upsides:
- A more intuitive way to work with flags.
- Possibility to easier remove default flags.
- Protection against removing required flags.
- Potentially fewer issues and frustration compared to the previous way.

Downsides:
- As today, people use `nil` to define a flag, so we may consider this a potential breaking change.