### PR TITLE
Add `env` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Ferrum::Browser.new(options)
       than this will cause a `Ferrum::DeadBrowserError`.
   * `:proxy` (Hash) - Specify proxy settings, [read more](https://github.com/rubycdp/ferrum#proxy)
   * `:save_path` (String) - Path to save attachments with [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header.
+  * `:env` (Hash) - Environment variables you'd like to pass through to the process
 
 
 ## Navigation

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -73,6 +73,7 @@ module Ferrum
 
         @logger = options[:logger]
         @process_timeout = options.fetch(:process_timeout, PROCESS_TIMEOUT)
+        @env = Hash(options[:env])
 
         tmpdir = Dir.mktmpdir("ferrum_user_data_dir_")
         ObjectSpace.define_finalizer(self, self.class.directory_remover(tmpdir))
@@ -95,7 +96,8 @@ module Ferrum
             ObjectSpace.define_finalizer(self, self.class.process_killer(@xvfb.pid))
           end
 
-          @pid = ::Process.spawn(Hash(@xvfb&.to_env), *@command.to_a, process_options)
+          env = Hash(@xvfb&.to_env).merge(@env)
+          @pid = ::Process.spawn(env, *@command.to_a, process_options)
           ObjectSpace.define_finalizer(self, self.class.process_killer(@pid))
 
           parse_ws_url(read_io, @process_timeout)

--- a/spec/unit/process_spec.rb
+++ b/spec/unit/process_spec.rb
@@ -21,6 +21,22 @@ module Ferrum
           subject.quit
         end
       end
+
+      context "env variables" do
+        subject { Browser.new(env: { "LD_PRELOAD" => "some.so" }) }
+
+        it "passes through env" do
+          allow(::Process).to receive(:wait).and_return(nil)
+          allow(Client).to receive(:new).and_return(double.as_null_object)
+
+          allow(::Process).to receive(:spawn).with({ "LD_PRELOAD" => "some.so" }, any_args)
+
+          allow_any_instance_of(Process).to receive(:parse_ws_url)
+
+          subject.send(:start)
+          subject.quit
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
**Issue**

Existing env variables may have an impact on a given chrome instance, and they sometimes overlap with env variables that are used in ruby. 

For instance, we've been having trouble with our dynamically linked jemalloc that is exported our env (`LD_PRELOAD`). The chrome instance didn't like this allocator version.

**Solution**

Hence I believe it would be nice to give one the opportunity to set those _only for the subprocess_.