### PR TITLE
Passes proxy settings to remote Chrome

### DIFF
--- a/lib/ferrum/contexts.rb
+++ b/lib/ferrum/contexts.rb
@@ -24,7 +24,17 @@ module Ferrum
     end
 
     def create
-      response = @browser.command("Target.createBrowserContext")
+      browser_options = @browser.options[:browser_options]
+
+      params = {}
+
+      # Passes the proxy-server params to the remote browser when using a
+      # remote browser.
+      @browser.options[:url] &&
+        browser_options&.key?("proxy-server") &&
+        params[:proxyServer] = browser_options["proxy-server"]
+
+      response = @browser.command("Target.createBrowserContext", params)
       context_id = response["browserContextId"]
       context = Context.new(@browser, self, context_id)
       @contexts[context_id] = context


### PR DESCRIPTION
This commit passes the 'proxy-server' parameter to a remote Chrome instance (meaning passing a `:url` parameter) so that you can use something like the puffing-billy gem as a MITM proxy to mock requests.

In my case, I have a dockerized Ruby On Rails application, using the Cucumber testing framework, with capybara and cuprite in order to manipulate a Chrome instance running in a separated container.
My app is using the Paddle payment processor and we'd like to mock calls to their APIs so we're using the [puffing-billy gem](https://github.com/oesmith/puffing-billy) which fires a proxy server acting as a VCR to record/replay requests.

[Being in the process of implementing the Cuprite driver to puffing-billy](https://github.com/oesmith/puffing-billy/issues/326), we were unable to get Chrome using the puffing-billy server until the change from this PR.