### PR TITLE
Handle file not found error in `Page#go_to`

### DIFF
--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -88,7 +88,8 @@ module Ferrum
       if %w[net::ERR_NAME_NOT_RESOLVED
             net::ERR_NAME_RESOLUTION_FAILED
             net::ERR_INTERNET_DISCONNECTED
-            net::ERR_CONNECTION_TIMED_OUT].include?(response["errorText"])
+            net::ERR_CONNECTION_TIMED_OUT
+            net::ERR_FILE_NOT_FOUND].include?(response["errorText"])
         raise StatusError, options[:url]
       end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Ferrum
+  describe Page do
+    describe "#go_to" do
+      it "raise an error when a non-existent file was specified" do
+        expect do
+          page.go_to("file:non-existent")
+        end.to raise_error(Ferrum::StatusError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Chrome allows to specify file scheme to an URL.
When a non-existent file is specified, Chrome returns `ERR_CONNECTION_TIMED_OUT`. But `ferrum` doesn't handle that error.
So in that case, an error happened, but it looked to work correctly.

This fixed to handle that error inside `go_to` and correctly raise an error.