### PR TITLE
Added `Ferrum::Browser#version`

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -9,6 +9,7 @@ require "ferrum/browser/xvfb"
 require "ferrum/browser/process"
 require "ferrum/browser/client"
 require "ferrum/browser/binary"
+require "ferrum/browser/version_info"
 
 module Ferrum
   class Browser
@@ -148,6 +149,10 @@ module Ferrum
 
     def crash
       command("Browser.crash")
+    end
+
+    def version
+      VersionInfo.new(command("Browser.getVersion"))
     end
 
     private

--- a/lib/ferrum/browser/version_info.rb
+++ b/lib/ferrum/browser/version_info.rb
@@ -1,0 +1,31 @@
+module Ferrum
+  class Browser
+    class VersionInfo
+
+      def initialize(properties)
+        @properties = properties
+      end
+
+      def protocol_version
+        @properties['protocolVersion']
+      end
+
+      def product
+        @properties['product']
+      end
+
+      def revision
+        @properties['revision']
+      end
+
+      def user_agent
+        @properties['userAgent']
+      end
+
+      def js_version
+        @properties['jsVersion']
+      end
+
+    end
+  end
+end

--- a/spec/browser/version_info_spec.rb
+++ b/spec/browser/version_info_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'ferrum/browser/version_info'
+
+describe Ferrum::Browser::VersionInfo do
+  let(:protocol_version) { "1.3" }
+  let(:product)          { "HeadlessChrome/106.0.5249.91" }
+  let(:revision)         { "@fa96d5f07b1177d1bf5009f647a5b8c629762157" }
+  let(:user_agent)       { "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/106.0.5249.91 Safari/537.36" }
+  let(:js_version)       { "10.6.194.17" }
+  let(:properties) do
+    {
+      "protocolVersion" => protocol_version,
+      "product"         => product,
+      "revision"        => revision,
+      "userAgent"       => user_agent,
+      "jsVersion"       => js_version
+    }
+  end
+
+  subject { described_class.new(properties) }
+
+  describe "#protocol_version" do
+    it "must return the 'protocolVersion' property" do
+      expect(subject.protocol_version).to eq(properties['protocolVersion'])
+    end
+  end
+
+  describe "#product" do
+    it "must return the 'product' property" do
+      expect(subject.product).to eq(properties['product'])
+    end
+  end
+
+  describe "#revision" do
+    it "must return the 'revision' property" do
+      expect(subject.revision).to eq(properties['revision'])
+    end
+  end
+
+  describe "#user_agent" do
+    it "must return the 'userAgent' property" do
+      expect(subject.user_agent).to eq(properties['userAgent'])
+    end
+  end
+
+  describe "#js_version" do
+    it "must return the 'jsVersion' property" do
+      expect(subject.js_version).to eq(properties['jsVersion'])
+    end
+  end
+end

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -74,6 +74,22 @@ module Ferrum
       expect(browser.body).to include("Hello world")
     end
 
+    it "must return allow requesting the browser version information" do
+      version_info = browser.version
+
+      expect(version_info).to be_kind_of(Ferrum::Browser::VersionInfo)
+      expect(version_info.protocol_version).to_not be(nil)
+      expect(version_info.protocol_version).to_not be_empty
+      expect(version_info.product).to_not be(nil)
+      expect(version_info.product).to_not be_empty
+      expect(version_info.revision).to_not be(nil)
+      expect(version_info.revision).to_not be_empty
+      expect(version_info.user_agent).to_not be(nil)
+      expect(version_info.user_agent).to_not be_empty
+      expect(version_info.js_version).to_not be(nil)
+      expect(version_info.js_version).to_not be_empty
+    end
+
     it "stops silently before goto call" do
       browser = Browser.new
       expect { browser.quit }.not_to raise_error


### PR DESCRIPTION
* Added `Ferrum::Browser#version` which calls the [`Browser.getVersion`](https://chromedevtools.github.io/devtools-protocol/1-3/Browser/#method-getVersion) command.
* Also added `Ferrum::Browser::VersionInfo` to wrap around the returned JSON hash.