### PR TITLE
Add support for `browser.on(:response)`.

### DIFF
--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -303,6 +303,14 @@ module Ferrum
           exchange.intercepted_request = request
           block.call(request, index, total)
         end
+      when :response
+        @client.on('Network.responseReceived') do |params, index, total|
+          exchange = network.select(params["requestId"]).last
+
+          if exchange
+            block.call(exchange, index, total)
+          end
+        end
       when :auth
         @client.on("Fetch.authRequired") do |params, index, total|
           request = Network::AuthRequest.new(self, params)


### PR DESCRIPTION
I wanted to be able to have a callback similar to `on(:request)` but triggered once a response was received. This adds an additional callback for the [`Network.responseReceived`](https://chromedevtools.github.io/devtools-protocol/1-3/Network/#event-responseReceived) event when a response is received. It will look up the `Ferrum::Network::Exchange` object with the matching `requestId` and passes it back to the block, once a response has been received for a request.

I didn't know where to add specs for this, since there does not appear to be specs for `Ferrum::Page` or a `spec/page_spec.rb` file? I also didn't know where I should mention `browser.on(:response)` in the README, since `browser.on(...)` is only mentioned in conjunction to using `browser.network.intercept`.