### PR TITLE
fix(core): undefined method url for nil:NilClass

### DIFF
--- a/lib/ferrum/network/exchange.rb
+++ b/lib/ferrum/network/exchange.rb
@@ -3,6 +3,9 @@
 module Ferrum
   class Network
     class Exchange
+      # ID of the request.
+      #
+      # @return String
       attr_reader :id
 
       # The intercepted request.
@@ -20,6 +23,9 @@ module Ferrum
       # @return [Response, nil]
       attr_accessor :response
 
+      # The error object.
+      #
+      # @return [Error, nil]
       attr_accessor :error
 
       #
@@ -45,8 +51,7 @@ module Ferrum
       # @return [Boolean]
       #
       def navigation_request?(frame_id)
-        request.type?(:document) &&
-          request.frame_id == frame_id
+        request.type?(:document) && request&.frame_id == frame_id
       end
 
       #
@@ -74,7 +79,7 @@ module Ferrum
       # @return [Boolean]
       #
       def finished?
-        blocked? || response || error
+        blocked? || !response.nil? || !error.nil?
       end
 
       #
@@ -92,7 +97,16 @@ module Ferrum
       # @return [Boolean]
       #
       def intercepted?
-        intercepted_request
+        !intercepted_request.nil?
+      end
+
+      #
+      # Returns request's URL.
+      #
+      # @return [String, nil]
+      #
+      def url
+        request&.url
       end
 
       #

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -130,7 +130,7 @@ module Ferrum
       response["frameId"]
     rescue TimeoutError
       if @browser.pending_connection_errors
-        pendings = network.traffic.select(&:pending?).map { |e| e.request.url }
+        pendings = network.traffic.select(&:pending?).map(&:url).compact
         raise PendingConnectionsError.new(options[:url], pendings) unless pendings.empty?
       end
     end
@@ -285,7 +285,7 @@ module Ferrum
         # changed which means there was some network event for
         # the main frame and it started to load new content.
         if iteration != @event.iteration
-          set = @event.wait(@browser.timeout)
+          set = @event.wait(timeout)
           raise TimeoutError unless set
         end
       end

--- a/spec/network/exchange_spec.rb
+++ b/spec/network/exchange_spec.rb
@@ -1,16 +1,160 @@
 # frozen_string_literal: true
 
-module Ferrum
-  class Network
-    describe Exchange do
-      it "captures refused connection errors" do
-        page.go_to("/ferrum/with_ajax_connection_refused")
-        expect(page.at_xpath("//h1[text() = 'Error']")).to be
+describe Ferrum::Network::Exchange do
+  describe "#url" do
+    it "returns url of the request" do
+      page.go_to
 
-        expect(last_exchange.error).to be
-        expect(last_exchange.response).to be_nil
-        expect(network.idle?).to be true
-      end
+      expect(last_exchange.url).to eq("http://127.0.0.1:#{server.port}/")
+    end
+
+    it "returns nil when request is blank" do
+      page.go_to
+
+      allow(last_exchange).to receive(:request) { nil }
+      expect(last_exchange.url).to be_nil
+    end
+  end
+
+  describe "#id" do
+    it "returns an id" do
+      page.go_to
+
+      expect(last_exchange.id).to be
+      expect(last_exchange.id).to be_a(String)
+    end
+  end
+
+  describe "#intercepted_request" do
+    it "returns request" do
+      network.intercept
+      page.on(:request) { |r, _, _| r.continue }
+
+      page.go_to
+
+      expect(page.body).to include("Hello world!")
+      expect(last_exchange.intercepted_request).to be
+      expect(last_exchange.intercepted_request).to be_a(Ferrum::Network::InterceptedRequest)
+    end
+  end
+
+  describe "#request" do
+    it "returns request" do
+      page.go_to
+
+      expect(last_exchange.request).to be
+      expect(last_exchange.request).to be_a(Ferrum::Network::Request)
+    end
+  end
+
+  describe "#response" do
+    it "returns request" do
+      page.go_to
+
+      expect(last_exchange.response).to be
+      expect(last_exchange.response).to be_a(Ferrum::Network::Response)
+    end
+  end
+
+  describe "#error" do
+    it "captures refused connection errors" do
+      page.go_to("/ferrum/with_ajax_connection_refused")
+      expect(page.at_xpath("//h1[text() = 'Error']")).to be
+
+      expect(last_exchange.error).to be
+      expect(last_exchange.error).to be_a(Ferrum::Network::Error)
+      expect(last_exchange.response).to be_nil
+      expect(network.idle?).to be true
+    end
+  end
+
+  describe "#navigation_request?" do
+    it "determines if exchange is navigational" do
+      page.go_to
+
+      expect(last_exchange.request).to be
+      expect(last_exchange.navigation_request?(page.main_frame.id)).to be true
+    end
+  end
+
+  describe "#blank?" do
+    it "determines if exchange is empty" do
+      page.go_to
+
+      expect(last_exchange.request).to be
+      expect(last_exchange.blank?).to be false
+    end
+  end
+
+  describe "#blocked?" do
+    it "determines if exchange was blocked" do
+      network.intercept
+      page.on(:request) { |r, _, _| r.abort }
+
+      page.go_to
+
+      expect(page.body).not_to include("Hello world!")
+      expect(last_exchange.blocked?).to be true
+    end
+  end
+
+  describe "#finished?" do
+    it "determines if exchange is fully finished" do
+      page.go_to
+
+      expect(last_exchange.finished?).to be true
+    end
+  end
+
+  describe "#pending?" do
+    it "determines if exchange is not fully loaded" do
+      allow(page).to receive(:timeout) { 2 }
+
+      expect do
+        page.go_to("/ferrum/visit_timeout")
+      end.to raise_error(
+        Ferrum::PendingConnectionsError,
+        %r{Request to http://.*/ferrum/visit_timeout reached server, but there are still pending connections: http://.*/ferrum/really_slow}
+      )
+      expect(last_exchange.pending?).to be true
+    end
+  end
+
+  describe "#intercepted?" do
+    it "determines if exchange is interrupted" do
+      network.intercept
+      page.on(:request) { |r, _, _| r.continue }
+
+      page.go_to
+
+      expect(last_exchange.intercepted_request).to be
+      expect(last_exchange.intercepted?).to be true
+    end
+  end
+
+  describe "#to_a" do
+    it "returns request, response and error" do
+      page.go_to
+
+      triple = last_exchange.to_a
+
+      expect(triple.size).to eq(3)
+      expect(triple).to eq([last_exchange.request, last_exchange.response, nil])
+    end
+  end
+
+  describe "#inspect" do
+    it "returns string for debugging" do
+      page.go_to
+
+      expect(last_exchange.inspect).to match(/
+        \#<Ferrum::Network::Exchange\s
+        @id=".+?"\s
+        @intercepted_request=nil\s
+        @request=\#<Ferrum::Network::Request.+?>\s
+        @response=\#<Ferrum::Network::Response.+?>\s
+        @error=nil>
+      /x)
     end
   end
 end


### PR DESCRIPTION
When request is missing and we try to raise PendingConnectionsError, we can get this error while building pending requests.