### PR TITLE
Adding logging around spawning and killing Chrome

### DIFF
--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -34,14 +34,14 @@ module Ferrum
             ::Process.kill("KILL", pid) unless system("taskkill /f /t /pid #{pid} >NUL 2>NUL")
           else
             ::Process.kill("USR1", pid)
-            logger&.puts("\nAttemping to kill chrome (#{pid})")
+            logger&.puts("\nAttemping to kill #{pid}")
             start = Utils::ElapsedTime.monotonic_time
             while ::Process.wait(pid, ::Process::WNOHANG).nil?
-              logger&.puts("Waiting for chrome (#{pid}) to end")
+              logger&.puts("Waiting for #{pid} to end")
               sleep(WAIT_KILLED)
               next unless Utils::ElapsedTime.timeout?(start, KILL_TIMEOUT)
 
-              logger&.puts("Forcefully killing chrome (#{pid})")
+              logger&.puts("Forcefully killing #{pid}")
               ::Process.kill("KILL", pid)
               ::Process.wait(pid)
               break

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -90,12 +90,12 @@ module Ferrum
         if ENV["FERRUM_CHROME_LOG"]
           File.open(ENV["FERRUM_CHROME_LOG"], "w") do |output_log|
             launch_chrome(stdout_and_stderr: output_log)
-            File.open(output_log.path, "r") do |read_from_log|
+            File.open(output_log.path, "r:#{Encoding.default_external}") do |read_from_log|
               parse_ws_url(read_from_log, @process_timeout, @pid)
             end
           end
         else
-          IO.pipe do |read_io, write_io|
+          IO.pipe(Encoding.default_external) do |read_io, write_io|
             begin
               launch_chrome(stdout_and_stderr: write_io)
               parse_ws_url(read_io, @process_timeout, @pid)

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -9,7 +9,6 @@ require "ferrum/browser/options/base"
 require "ferrum/browser/options/chrome"
 require "ferrum/browser/options/firefox"
 require "ferrum/browser/command"
-require "pry"
 
 module Ferrum
   class Browser

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -186,10 +186,10 @@ module Ferrum
           end
         end
 
+        @logger&.puts("chrome (#{pid}) IO stream output: #{output}***\n")
         return if ws_url
 
         log_chrome_ps(pid, "\nNo websocket detected for chrome")
-        @logger&.puts("chrome (#{pid}) IO stream output: #{output}***\n")
         raise ProcessTimeoutError.new(timeout, output)
       end
 

--- a/lib/ferrum/version.rb
+++ b/lib/ferrum/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ferrum
-  VERSION = "0.13"
+  VERSION = "0.13.1"
 end


### PR DESCRIPTION
Adds additional logging around:
- spawning the chrome process
- detecting the websocket
- ps output for the running process (to demonstrate that we have a consecutive browser instance)
- closing the browser process

All of this logging ends up in the logger, in our case capybara(_mobile).log