### PR TITLE
Use Promise in example for #evaluate_async

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,15 +826,19 @@ browser.evaluate("[window.scrollX, window.scrollY]")
 
 #### evaluate_async(expression, wait_time, \*args)
 
-Evaluate asynchronous expression and return result
+Evaluate an asynchronous expression and return result
 
-* expression `String` should be valid JavaScript
+* expression `String` should be valid JavaScript, and include the fulfill callback: `__f()`
 * wait_time How long we should wait for Promise to resolve or reject
 * args `Object` you can pass arguments, though it should be a valid `Node` or a
 simple value.
 
 ```ruby
-browser.evaluate_async(%(arguments[0]({foo: "bar"})), 5) # => { "foo" => "bar" }
+browser.evaluate_async <<JS, 5
+  fetch("https://www.httpbin.org/json")
+    .then(response => response.json())
+    .then(body => __f(body))
+JS
 ```
 
 #### execute(expression, \*args)


### PR DESCRIPTION
Related to #234

I couldn't remember how to get a value back from `evaluate_async` and remembered I had created an example in a previous issue. 

The existing example leverages `arguments[0]` and calls a simple object. Instead, I would like to see an actual, practical example using familiar things that people would commonly use this for.

Additionally, I think we should encourage usage of `__f()` as in the next example, instead of `arguments[0]`, or rework the `#evaluate_async` template. As an example, if you call:

```ruby
browser.evaluate_async '__f(arguments)', 5, "arg 1", 2, 3
# => ["arg 1", 2, 3, {}]
```

`arguments[0]` no longer refers to the fulfill callback. You end up receiving ` TypeError: arguments[0] is not a function (Ferrum::JavaScriptError)`.

Perhaps this highlights some tweaks that could be made to `evaluate_async`, but for now, I'd like to get this docs change up asap.