### PR TITLE
Fix truncated Chrome WS URL that results in intermittent `Ferrum::DeadBrowserError`

### DIFF
--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -137,7 +137,7 @@ module Ferrum
         output = ""
         start = Utils::ElapsedTime.monotonic_time
         max_time = start + timeout
-        regexp = %r{DevTools listening on (ws://.*)}
+        regexp = %r{DevTools listening on (ws://.*[a-zA-Z0-9-]{36})}
         while (now = Utils::ElapsedTime.monotonic_time) < max_time
           begin
             output += read_io.read_nonblock(512)


### PR DESCRIPTION
## Details
The Chrome WebSocket URL is read from the IO with the following:
https://github.com/rubycdp/ferrum/blob/a71634d065cd976626e1b612134f2ef5eef90d67/lib/ferrum/browser/process.rb#L142-L150

As 512 bytes are read at a time, it occasionally occurs that we get a truncated WebSocket URL. For example, that is the output of the `ws_url` variable within a CI tests run that failed:

```
ws://127.0.0.1:35663/devtools/browser/a3603fc2-ed48-497d-9c1e-057b08f83aaf
ws://127.0.0.1:45503/devtools/browser/4db98447-c685-4a71-a7d5-146f2c2f24c5
...
ws://127.0.0.1:33327/devtools/browser/bab2421f-9b04-49af-8a50-e6802c21fa0c
ws://127.0.0.1:36173/devtools/browser/e1b4a3fa-c230-4422-ac82-ecf77858b33f
ws://127.0.0.1:42227/devtools/browser/907bc2f7-20ea-42e2-b1ea
ws://127.0.0.1:45059/devtools/browser/a36c4ddc-e6dc-4e65-bbe6-5d8ecbf653c5
...
```

As you can see, the `ws://127.0.0.1:42227/devtools/browser/907bc2f7-20ea-42e2-b1ea` one is truncated which eventually result in the driver raising a `Ferrum::DeadBrowserError` exception. 

## Proposed solution
The proposed fix is to enhance the regex by checking that the URL ends with a complete UUID. 

## Alternative solution
The logic could be changed to read the IO line by line instead of a fixed 512 bytes as Chrome is outputting with line breaks. 