### PR TITLE
Fix `Ferrum::Network::Response#loaded?` for redirect response

### DIFF
--- a/lib/ferrum/network.rb
+++ b/lib/ferrum/network.rb
@@ -362,6 +362,7 @@ module Ferrum
         if params["redirectResponse"]
           previous_exchange = select(request.id)[-2]
           response = Network::Response.new(@page, params)
+          response.loaded = true
           previous_exchange.response = response
         end
 


### PR DESCRIPTION
# Issue
Fixes https://github.com/rubycdp/ferrum/issues/321

# Context
Redirect `Ferrum::Network::Response` are created within the `Network.requestWillBeSent` event:

https://github.com/rubycdp/ferrum/blob/e2340b3458a74beece94e0156c4dea05f191259b/lib/ferrum/network.rb#L358-L366

Additionally, the `Network.loadingFinished` event is where responses are marked as `loaded = true`:
https://github.com/rubycdp/ferrum/blob/e2340b3458a74beece94e0156c4dea05f191259b/lib/ferrum/network.rb#L386-L392

As redirect responses are sharing the same `requestId` and as that code is only selecting the last exchange response e.g. the final response, only that exchange response is marked as `loaded?`.

# Proposed fix
Assigning `loaded = true` at the time that redirect response object is created.

**Note:** Unfortunately I'm running into issues executing tests locally so I didn't add any. Per my quick testing, it looks to be solving the aforementioned issue. 