### PR TITLE
Websocket connection remains indefinitely in `:connecting` state and causes `TimeoutError`

### DIFF
--- a/lib/ferrum/browser/web_socket.rb
+++ b/lib/ferrum/browser/web_socket.rb
@@ -7,7 +7,7 @@ require "websocket/driver"
 module Ferrum
   class Browser
     class WebSocket
-      WEBSOCKET_BUG_SLEEP = 0.01
+      WEBSOCKET_BUG_SLEEP = 0.05
       SKIP_LOGGING_SCREENSHOTS = !ENV["FERRUM_LOGGING_SCREENSHOTS"]
 
       attr_reader :url, :messages


### PR DESCRIPTION
## Issue
Within a test run, we're intermittently get a `TimeoutError`. 

## Root cause
It is caused by the Websocket that remains in a `:connecting` state - that behavior is also discussed in https://github.com/rubycdp/cuprite/pull/36

## Proposed fix
By bumping the sleep to `0.05` we're no longer getting the issue but that is probably not ideal. In full transparency, I haven't tried any lower sleep time as I think the performance hit is fine.  