### PR TITLE
Limit emulation to enabling slowmoable

### DIFF
--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -145,7 +145,7 @@ module Ferrum
       command("Emulation.setDeviceMetricsOverride", slowmoable: true,
                                                     width: width,
                                                     height: height,
-                                                    deviceScaleFactor: 1,
+                                                    deviceScaleFactor: 0,
                                                     mobile: false,
                                                     fitWindow: false)
     end


### PR DESCRIPTION
Fixes #330 

If the line cannot be removed (because `slowmoable` needs to stay enabled) then this will disable the override of everything else.