### PR TITLE
Handle nil request in `Exchange#navigation_request?`

### DIFF
--- a/lib/ferrum/network/exchange.rb
+++ b/lib/ferrum/network/exchange.rb
@@ -51,7 +51,7 @@ module Ferrum
       # @return [Boolean]
       #
       def navigation_request?(frame_id)
-        request.type?(:document) && request&.frame_id == frame_id
+        request&.type?(:document) && request&.frame_id == frame_id
       end
 
       #


### PR DESCRIPTION
## Details
As the `Exchange` object is pushed to the network traffic before assigning its `request`, it is assumed that the `request` can be `nil` in the exchange object. 

https://github.com/rubycdp/ferrum/blob/d14161363c0a7b75c23f9c37a382eb838fa4b76b/lib/ferrum/network.rb#L355-L357
https://github.com/rubycdp/ferrum/blob/d14161363c0a7b75c23f9c37a382eb838fa4b76b/lib/ferrum/network.rb#L368

For that reason, the `#navigation_request?` method was updated to be `nil` safe.