### PR TITLE
Raise `Ferrum::StatusError` for any top frame navigation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,9 +595,8 @@ Activates offline mode for a page.
 
 ```ruby
 browser.network.offline_mode
-browser.go_to("https://github.com/") # => Ferrum::StatusError (Request to https://github.com/ failed to reach server, check DNS and server status)
+browser.go_to("https://github.com/") # => Ferrum::StatusError (Request to https://github.com/ failed(net::ERR_INTERNET_DISCONNECTED))
 ```
-
 
 ## Proxy
 

--- a/lib/ferrum/network.rb
+++ b/lib/ferrum/network.rb
@@ -333,8 +333,7 @@ module Ferrum
     #
     # @example
     #   browser.network.offline_mode
-    #   browser.go_to("https://github.com/") # => Ferrum::StatusError (Request to https://github.com/ failed to reach
-    #   server, check DNS and server status)
+    #   browser.go_to("https://github.com/") # => Ferrum::StatusError (Request to https://github.com/ failed (net::ERR_INTERNET_DISCONNECTED))
     #
     def offline_mode
       emulate_network_conditions(offline: true, latency: 0, download_throughput: 0, upload_throughput: 0)

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -114,14 +114,7 @@ module Ferrum
       options = { url: combine_url!(url) }
       options.merge!(referrer: referrer) if referrer
       response = command("Page.navigate", wait: GOTO_WAIT, **options)
-      # https://cs.chromium.org/chromium/src/net/base/net_error_list.h
-      if %w[net::ERR_NAME_NOT_RESOLVED
-            net::ERR_NAME_RESOLUTION_FAILED
-            net::ERR_INTERNET_DISCONNECTED
-            net::ERR_CONNECTION_TIMED_OUT
-            net::ERR_FILE_NOT_FOUND].include?(response["errorText"])
-        raise StatusError, options[:url]
-      end
+      raise StatusError.new(options[:url], "Request to #{options[:url]} failed (#{response['errorText']})") if response['errorText']
 
       response["frameId"]
     rescue TimeoutError

--- a/spec/network/exchange_spec.rb
+++ b/spec/network/exchange_spec.rb
@@ -91,7 +91,12 @@ describe Ferrum::Network::Exchange do
       network.intercept
       page.on(:request) { |r, _, _| r.abort }
 
-      page.go_to
+      expect do
+        page.go_to
+      end.to raise_error(
+        Ferrum::StatusError,
+        %r{Request to http://127.0.0.1:#{server.port} failed \(net::ERR_BLOCKED_BY_CLIENT\)}
+      )
 
       expect(page.body).not_to include("Hello world!")
       expect(last_exchange.blocked?).to be true

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -456,7 +456,7 @@ describe Ferrum::Network do
 
     expect { page.go_to("/ferrum/with_js") }.to raise_error(
       Ferrum::StatusError,
-      %r{Request to http://.*/ferrum/with_js failed to reach server, check DNS and server status}
+      %r{Request to http://.*/ferrum/with_js failed \(net::ERR_INTERNET_DISCONNECTED\)}
     )
 
     expect(page.body).to eq("<html><head></head><body></body></html>")

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -16,32 +16,10 @@ describe Ferrum::Page do
     end
 
     context "with failing response" do
-      it "handles when a non-existent file was specified" do
-        file_name = "file:non-existent"
-
-        expect do
-          page.go_to(file_name)
-        end.to raise_error(
-          Ferrum::StatusError,
-          "Request to #{file_name} failed to reach server, check DNS and server status"
-        )
-      end
-
-      it "handles when DNS is incorrect" do
+      it "handles navigation error" do
         expect { page.go_to("http://nope:#{port}/") }.to raise_error(
           Ferrum::StatusError,
-          %r{Request to http://nope:\d+/ failed to reach server, check DNS and server status}
-        )
-      end
-
-      it "has a descriptive message when DNS incorrect" do
-        url = "http://nope:#{port}/"
-
-        expect do
-          page.go_to(url)
-        end.to raise_error(
-          Ferrum::StatusError,
-          /Request to #{url} failed to reach server, check DNS and server status/
+          %r{Request to http://nope:\d+/ failed \(net::ERR_NAME_NOT_RESOLVED\)}
         )
       end
 


### PR DESCRIPTION
## Context
The `Page#go_to` is only raising a `Ferrum::StatusError` for a subset of exceptions:

https://github.com/rubycdp/ferrum/blob/0cab51d1f0500efa7573cac39f99c44421f81c86/lib/ferrum/page.rb#L113-L124

Per the Chrome DevTools [documentation](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-navigate) an `errorText` is present if and only if navigation has failed.

## Proposal
This PR is proposing to raise regardless of the `errorText` given that the navigation failed. 

> **Warning**
This could be considered as a breaking change.

## Reference
Discussion: https://github.com/rubycdp/ferrum/discussions/340