### PR TITLE
Add Ruby 3.2 to CI.  Upgrade actions.  Quote 3.0.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,31 +7,17 @@ jobs:
      strategy:
        fail-fast: false
        matrix:
-         ruby: [ 2.7, 3.0 ]
+         ruby: [ 2.7, "3.0" ]
      runs-on: ubuntu-latest
      steps:
        - name: Checkout code
-         uses: actions/checkout@v2
+         uses: actions/checkout@v3
 
        - name: Setup Ruby
          uses: ruby/setup-ruby@v1
          with:
            ruby-version: ${{ matrix.ruby }}
            bundler-cache: true
-
-       - name: Ruby gem cache
-         uses: actions/cache@v1
-         with:
-           path: vendor/bundle
-           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-           restore-keys: |
-             ${{ runner.os }}-gems-
-
-       - name: Install gems
-         run: |
-           bundle config path vendor/bundle
-           bundle install --jobs 4 --retry 3
-
        - name: Run linters
          run: |
            bundle exec rubocop --parallel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         gemfile: [websocket-driver-0.6.x, websocket-driver-0.7.x]
-        ruby: [2.6, 2.7, 3.0, 3.1]
+        ruby: [2.6, 2.7, "3.0", 3.1, 3.2]
     runs-on: ubuntu-latest
     env:
       FERRUM_PROCESS_TIMEOUT: 20
@@ -20,7 +20,7 @@ jobs:
       BUNDLE_GEMFILE: .github/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -39,7 +39,7 @@ jobs:
         run: bundle exec rake
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: footprints


### PR DESCRIPTION
This PR adds Ruby 3.2 to the CI matrix.  It also does a little bit of cleanup.

Specific cleanup items include:

1. Simplifying the linter file by eliminating the separate `bundle install` and `cache` steps, instead using the packaged bundling in `setup-ruby` as in the test file
2. Quoting the "3.0" instances.  Unquoted "3.0" is truncated to "3" by GitHub Actions, invoking the latest Ruby 3 (at this time of writing Ruby 3.2.1).  Quoting ensures the intended Ruby version is loaded.
3. Updating the `checkout` and `upload-artifact` actions to v3

Everything runs green on my fork, although a few test tasks failed on first run and needed to be rerun.
