### PR TITLE
fix warn instructions in page.rb

### DIFF
--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -348,7 +348,7 @@ module Ferrum
       on(:dialog) do |dialog, _index, total|
         if total == 1
           warn "Dialog was shown but you didn't provide `on(:dialog)` callback, accepting it by default. " \
-               "Please take a look at https://github.com/rubycdp/ferrum#dialog"
+               "Please take a look at https://github.com/rubycdp/ferrum#dialogs"
           dialog.accept
         end
       end


### PR DESCRIPTION
https://github.com/rubycdp/ferrum#dialog doesn't lead anywhere :) link is #dialogs