### PR TITLE
Helpful information for those running in Docker on M1 Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ In docker as root you must pass the no-sandbox browser option:
 Ferrum::Browser.new(browser_options: { 'no-sandbox': nil })
 ```
 
+It has also been reported that the Chrome process repeatedly crashes when running inside a Docker container on an M1 Mac. After deploying to a container on an AWS server the problem goes away.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ In docker as root you must pass the no-sandbox browser option:
 Ferrum::Browser.new(browser_options: { 'no-sandbox': nil })
 ```
 
-It has also been reported that the Chrome process repeatedly crashes when running inside a Docker container on an M1 Mac. After deploying to a container on an AWS server the problem goes away.
+It has also been reported that the Chrome process repeatedly crashes when running inside a Docker container on an M1 Mac preventing Ferrum from working. Ferrum should work as expected when deployed to a Docker container on a non-M1 Mac.
 
 ## Customization
 


### PR DESCRIPTION
After failing to get Ferrum working inside a docker container on an M1 mac, I deployed to AWS and it worked fine. I was having the same issue described in https://github.com/rubycdp/ferrum/issues/270