### PR TITLE
Protect against calling `.quit` on the browser object twice.

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -237,9 +237,11 @@ module Ferrum
     end
 
     def quit
-      @client.close
-      @process.stop
-      @client = @process = @contexts = nil
+      if @client
+        @client.close
+        @process.stop
+        @client = @process = @contexts = nil
+      end
     end
 
     def resize(**options)


### PR DESCRIPTION
Discovered that you can accidentally call `.quit` twice on the `browser` instance, and that causes the following exception:

```
/home/postmodern/test/ruby/bundler/vendor/bundle/ruby/3.2.0/gems/ferrum-0.13/lib/ferrum/browser.rb:240:in `quit': undefined method `close' for nil:NilClass (NoMethodError)

      @client.close
             ^^^^^^
	from test.rb:13:in `<main>'
```