### PR TITLE
Added common `RequestParams` for both `Request` and `InterceptedRequest`

### DIFF
--- a/lib/ferrum/network/intercepted_request.rb
+++ b/lib/ferrum/network/intercepted_request.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require "ferrum/network/request_params"
 require "base64"
 
 module Ferrum
   class Network
     class InterceptedRequest
+      include RequestParams
+
       attr_accessor :request_id, :frame_id, :resource_type, :network_id, :status
 
       def initialize(page, params)
@@ -52,18 +55,6 @@ module Ferrum
       def abort
         @status = :aborted
         @page.command("Fetch.failRequest", requestId: request_id, errorReason: "BlockedByClient")
-      end
-
-      def url
-        @request["url"]
-      end
-
-      def method
-        @request["method"]
-      end
-
-      def headers
-        @request["headers"]
       end
 
       def initial_priority

--- a/lib/ferrum/network/request.rb
+++ b/lib/ferrum/network/request.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "ferrum/network/request_params"
 require "time"
 
 module Ferrum
@@ -9,6 +10,8 @@ module Ferrum
     # object.
     #
     class Request
+      include RequestParams
+
       #
       # Initializes the request object.
       #
@@ -69,42 +72,6 @@ module Ferrum
       end
 
       #
-      # The URL for the request.
-      #
-      # @return [String]
-      #
-      def url
-        @request["url"]
-      end
-
-      #
-      # The URL fragment for the request.
-      #
-      # @return [String, nil]
-      #
-      def url_fragment
-        @request["urlFragment"]
-      end
-
-      #
-      # The request method.
-      #
-      # @return [String]
-      #
-      def method
-        @request["method"]
-      end
-
-      #
-      # The request headers.
-      #
-      # @return [Hash{String => String}]
-      #
-      def headers
-        @request["headers"]
-      end
-
-      #
       # The request timestamp.
       #
       # @return [Time]
@@ -112,17 +79,6 @@ module Ferrum
       def time
         @time ||= Time.strptime(@params["wallTime"].to_s, "%s")
       end
-
-      #
-      # The optional HTTP `POST` form data.
-      #
-      # @return [String, nil]
-      #   The HTTP `POST` form data.
-      #
-      def post_data
-        @request["postData"]
-      end
-      alias body post_data
 
       #
       # Converts the request to a Hash.

--- a/lib/ferrum/network/request_params.rb
+++ b/lib/ferrum/network/request_params.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Ferrum
+  class Network
+    #
+    # Common methods used by both {Request} and {InterceptedRequest}.
+    #
+    module RequestParams
+      #
+      # The URL for the request.
+      #
+      # @return [String]
+      #
+      def url
+        @request["url"]
+      end
+
+      #
+      # The URL fragment for the request.
+      #
+      # @return [String, nil]
+      #
+      def url_fragment
+        @request["urlFragment"]
+      end
+
+      #
+      # The request method.
+      #
+      # @return [String]
+      #
+      def method
+        @request["method"]
+      end
+
+      #
+      # The request headers.
+      #
+      # @return [Hash{String => String}]
+      #
+      def headers
+        @request["headers"]
+      end
+
+      #
+      # The optional HTTP `POST` form data.
+      #
+      # @return [String, nil]
+      #   The HTTP `POST` form data.
+      #
+      def post_data
+        @request["postData"]
+      end
+      alias body post_data
+    end
+  end
+end


### PR DESCRIPTION
Extracted common methods that provide access to `@request` params for both `Ferrum::Network::Request` and `Ferrum::Network::InterceptedRequest`, so that they have similar methods. Previously, `InterceptedRequest` was missing a `body` method for accessing `@request['postData']`.