### PR TITLE
Page closed safely

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -177,7 +177,7 @@ module Ferrum
       block_given? ? yield(page) : page
     ensure
       if block_given?
-        page.close
+        page&.close
         context.dispose if new_context
       end
     end


### PR DESCRIPTION
A check is added to ensure that the page object is not nil before attempting to close it