### PR TITLE
Allows disable javascript from HTML source in the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/rubycdp/ferrum/compare/v0.14...main) ##
 
 ### Added
+- `Ferrum::Page#disable_javascript` disables the JavaScript from the HTML source
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -909,6 +909,19 @@ browser.evaluate("window.__injected") # => 42
 ```
 
 
+## Emulation
+
+#### disable_javascript
+
+Disables Javascripts from the loaded HTML source.
+You can still evaluate JavaScript with `evaluate` or `execute`.
+Returns nothing.
+
+```ruby
+browser.disable_javascript
+```
+
+
 ## Frames
 
 #### frames : `Array[Frame] | []`

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -27,7 +27,8 @@ module Ferrum
                 evaluate evaluate_on evaluate_async execute evaluate_func
                 add_script_tag add_style_tag bypass_csp
                 on position position=
-                playback_rate playback_rate=] => :page
+                playback_rate playback_rate=
+                disable_javascript] => :page
     delegate %i[default_user_agent] => :process
 
     attr_reader :client, :process, :contexts, :options, :window_size, :base_url

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -150,6 +150,15 @@ module Ferrum
     end
 
     #
+    # Disables JavaScript execution from the HTML source for the page.
+    #
+    # This doesn't prevent users evaluate JavaScript with Ferrum.
+    #
+    def disable_javascript
+      command("Emulation.setScriptExecutionDisabled", value: true)
+    end
+
+    #
     # The current position of the browser window.
     #
     # @return [(Integer, Integer)]

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -170,4 +170,20 @@ describe Ferrum::Page do
       expect { page.go_to("/ferrum/really_slow") }.to raise_error(Ferrum::PendingConnectionsError)
     end
   end
+
+  describe "#disable_javascript" do
+    it "disables javascripts on page" do
+      page.disable_javascript
+
+      expect { page.go_to("/ferrum/js_error") }.not_to raise_error
+    end
+
+    it "allows javascript evaluation from Ferrum" do
+      page.disable_javascript
+
+      page.evaluate("document.body.innerHTML = '<p>text</p>'")
+
+      expect(page.main_frame.body).to eq("<html><head></head><body><p>text</p></body></html>")
+    end
+  end
 end


### PR DESCRIPTION
Additional security measure for users not needing JavaScript.

Fixes #389 