### PR TITLE
feat: Supports capture area screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,12 @@ Saves screenshot on a disk or returns it as base64.
   * :format `String` "jpeg" | "png"
   * :quality `Integer` 0-100 works for jpeg only
   * :full `Boolean` whether you need full page screenshot or a viewport
-  * :selector `String` css selector for given element
+  * :selector `String` css selector for given element, optional
+  * :area `Hash` area for screenshot, optional
+    * :x `Integer`
+    * :y `Integer`
+    * :width `Integer`
+    * :height `Integer`
   * :scale `Float` zoom in/out
   * :background_color `Ferrum::RGBA.new(0, 0, 0, 0.0)` to have specific background color
 
@@ -370,7 +375,11 @@ browser.screenshot(path: "google.png") # => 134660
 # Save on the disk in JPG
 browser.screenshot(path: "google.jpg") # => 30902
 # Save to Base64 the whole page not only viewport and reduce quality
-browser.screenshot(full: true, quality: 60) # "iVBORw0KGgoAAAANSUhEUgAABAAAAAMACAYAAAC6uhUNAAAAAXNSR0IArs4c6Q...
+browser.screenshot(full: true, quality: 60, encoding: :base64) # "iVBORw0KGgoAAAANSUhEUgAABAAAAAMACAYAAAC6uhUNAAAAAXNSR0IArs4c6Q...
+# Save on the disk with the selected element in PNG
+browser.screenshot(path: "google.png", selector: 'textarea') # => 11340
+# Save to Base64 with an area of the page in PNG
+browser.screenshot(path: "google.png", area: { x: 0, y: 0, width: 400, height: 300 }) # => 54239
 # Save with specific background color
 browser.screenshot(background_color: Ferrum::RGBA.new(0, 0, 0, 0.0))
 ```

--- a/lib/ferrum/page/screenshot.rb
+++ b/lib/ferrum/page/screenshot.rb
@@ -5,6 +5,9 @@ require "ferrum/rgba"
 module Ferrum
   class Page
     module Screenshot
+      PARTIAL_SCREENSHOT_ARGUMENTS_MESSAGE = "Ignoring :selector or :area in #screenshot since full: true was given at "
+      AREA_SCREENSHOT_ARGUMENT_MESSAGE = "Ignoring :area in #screenshot since selector: was given at "
+
       DEFAULT_PDF_OPTIONS = {
         landscape: false,
         paper_width: 8.5,
@@ -49,6 +52,9 @@ module Ferrum
       #
       # @option opts [String] :selector
       #   CSS selector for the given element.
+      #
+      # @option opts [Hash] :area
+      #   x, y, width, height to screenshot an area.
       #
       # @option opts [Float] :scale
       #   Zoom in/out.
@@ -198,7 +204,7 @@ module Ferrum
         screenshot_options.merge!(quality: quality) if quality
         screenshot_options.merge!(format: format)
 
-        clip = area_options(options[:full], options[:selector], scale)
+        clip = area_options(options[:full], options[:selector], scale, options[:area])
         screenshot_options.merge!(clip: clip) if clip
 
         screenshot_options
@@ -214,27 +220,33 @@ module Ferrum
         [format, quality]
       end
 
-      def area_options(full, selector, scale)
-        message = "Ignoring :selector in #screenshot since full: true was given at #{caller(1..1).first}"
-        warn(message) if full && selector
+      def area_options(full, selector, scale, area = nil)
+        warn("#{PARTIAL_SCREENSHOT_ARGUMENTS_MESSAGE}#{caller(1..1).first}") if full && (selector || area)
+        warn("#{AREA_SCREENSHOT_ARGUMENT_MESSAGE}#{caller(1..1).first}") if selector && area
 
         clip = if full
-                 width, height = document_size
-                 { x: 0, y: 0, width: width, height: height, scale: scale } if width.positive? && height.positive?
+                 full_window_area || viewport_area
                elsif selector
-                 bounding_rect(selector).merge(scale: scale)
+                 bounding_rect(selector)
+               elsif area
+                 area
+               else
+                 viewport_area
                end
 
-        if scale != 1
-          unless clip
-            width, height = viewport_size
-            clip = { x: 0, y: 0, width: width, height: height }
-          end
-
-          clip.merge!(scale: scale)
-        end
+        clip.merge!(scale: scale)
 
         clip
+      end
+
+      def full_window_area
+        width, height = document_size
+        { x: 0, y: 0, width: width, height: height } if width.positive? && height.positive?
+      end
+
+      def viewport_area
+        width, height = viewport_size
+        { x: 0, y: 0, width: width, height: height }
       end
 
       def bounding_rect(selector)


### PR DESCRIPTION
Fixes #389

I made `selector` and `area` optional arguments. In the implementation, I think that the pull requests shows the true intention of the screenshot region.

If `full: true`, It tries to capture full screenshot with full size browser window and then viewport if the full size is not accurate.
If `full: false`, `:selector` is preferred if defined. Then `:area`. Otherwise, the default will be the viewport.

Applying default scale (1.0) will not affect the result anyway.