### PR TITLE
Stop process if error during initialise

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -266,11 +266,21 @@ module Ferrum
 
     def start
       Utils::ElapsedTime.start
-      @process = Process.start(options)
-      @client = Client.new(@process.ws_url, self,
-                           logger: options.logger,
-                           ws_max_receive_size: options.ws_max_receive_size)
-      @contexts = Contexts.new(self)
+      @process = Process.new(options)
+
+      begin
+        @process.start
+        @client = Client.new(
+          @process.ws_url,
+          self,
+          logger: options.logger,
+          ws_max_receive_size: options.ws_max_receive_size
+        )
+        @contexts = Contexts.new(self)
+      rescue
+        @process.stop
+        raise
+      end
     end
   end
 end

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -252,6 +252,35 @@ describe Ferrum::Browser do
         end
       end
     end
+
+    it "stops process if an error is raised during process start" do
+      process = Ferrum::Browser::Process.new(Ferrum::Browser::Options.new(process_timeout: 0))
+      allow(Ferrum::Browser::Process).to receive(:new).and_return(process)
+      expect { Ferrum::Browser.new }.to raise_error(Ferrum::ProcessTimeoutError)
+      expect(process.pid).to be(nil)
+    end
+
+    it "stops process if an error is raised during client creation" do
+      process = Ferrum::Browser::Process.new(Ferrum::Browser::Options.new)
+      allow(Ferrum::Browser::Process).to receive(:new).and_return(process)
+
+      error = StandardError.new
+      allow(Ferrum::Browser::Client).to receive(:new).and_raise(error)
+
+      expect { Ferrum::Browser.new }.to raise_error(error)
+      expect(process.pid).to be(nil)
+    end
+
+    it "stops process if an error is raised during contexts creation" do
+      process = Ferrum::Browser::Process.new(Ferrum::Browser::Options.new)
+      allow(Ferrum::Browser::Process).to receive(:new).and_return(process)
+
+      error = StandardError.new
+      allow(Ferrum::Contexts).to receive(:new).and_raise(error)
+
+      expect { Ferrum::Browser.new }.to raise_error(error)
+      expect(process.pid).to be(nil)
+    end
   end
 
   describe "#crash" do


### PR DESCRIPTION
We use Ferrum with Puma and found that if an error is raised during initialisation of the browser, then chrome processes do not get stopped until the garbage collection runs. 

Equally there is no way to stop these processes from the perspective of somebody using Ferrum because we never get a browser object back as the initialize method is raising the error.

From what i can tell, garbage collection doesn't run immediately and so these processes can live for longer then they need to.

By catching any errors raised between the process being started and returning from the browser initialiser then we can ensure that we stop any processes which were started.