### PR TITLE
Fix: Do not expect response for initiatorType Ping requests

### DIFF
--- a/lib/ferrum/network/exchange.rb
+++ b/lib/ferrum/network/exchange.rb
@@ -119,6 +119,17 @@ module Ferrum
       end
 
       #
+      # Determines if the exchange expects a response
+      #
+      # @return [Boolean]
+      #
+      def response_expected?
+        return true if request.nil?
+
+        !!request.response_expected?
+      end
+
+      #
       # Returns request's URL.
       #
       # @return [String, nil]

--- a/lib/ferrum/network/exchange.rb
+++ b/lib/ferrum/network/exchange.rb
@@ -79,7 +79,7 @@ module Ferrum
       # @return [Boolean]
       #
       def finished?
-        blocked? || response&.loaded? || !error.nil?
+        blocked? || response&.loaded? || !error.nil? || !response_expected?
       end
 
       #

--- a/lib/ferrum/network/request.rb
+++ b/lib/ferrum/network/request.rb
@@ -81,6 +81,15 @@ module Ferrum
       end
 
       #
+      # Determines if a response is expected.
+      #
+      # @return [Boolean]
+      #
+      def response_expected?
+        !type?("ping")
+      end
+
+      #
       # Converts the request to a Hash.
       #
       # @return [Hash{String => Object}]

--- a/spec/network/exchange_spec.rb
+++ b/spec/network/exchange_spec.rb
@@ -119,6 +119,16 @@ describe Ferrum::Network::Exchange do
     end
   end
 
+  describe "#response_expected?" do
+    it "determines if exchange expects a response" do
+      exchange = Ferrum::Network::Exchange.new(page, "1")
+      expect(exchange.response_expected?).to be true
+
+      exchange.request = Ferrum::Network::Request.new({"type" => "Ping"})
+      expect(exchange.response_expected?).to be false
+    end
+  end
+
   describe "#pending?" do
     it "determines if exchange is not fully loaded" do
       allow(page).to receive(:timeout) { 2 }

--- a/spec/network/exchange_spec.rb
+++ b/spec/network/exchange_spec.rb
@@ -109,6 +109,22 @@ describe Ferrum::Network::Exchange do
 
       expect(last_exchange.finished?).to be true
     end
+
+    it "returns true if an error occurred" do
+      exchange = Ferrum::Network::Exchange.new(page, "1")
+
+      expect(exchange.finished?).to be false
+      exchange.error = Ferrum::Network::Error.new
+      expect(exchange.finished?).to be true
+    end
+
+    it "returns true for ping requests" do
+      exchange = Ferrum::Network::Exchange.new(page, "1")
+      expect(exchange.finished?).to be false
+
+      exchange.request = Ferrum::Network::Request.new({"type" => "Ping"})
+      expect(exchange.finished?).to be true
+    end
   end
 
   describe "#redirect?" do

--- a/spec/network/request_spec.rb
+++ b/spec/network/request_spec.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
 describe Ferrum::Network::Request do
-  skip
+  describe "#response_expected?" do
+    it "returns true for document requests" do
+      request = Ferrum::Network::Request.new({"type" => "Document"})
+
+      expect(request.response_expected?).to be(true)
+    end
+
+    it "returns false for ping requests" do
+      request = Ferrum::Network::Request.new({"type" => "Ping"})
+
+      expect(request.response_expected?).to be(false)
+    end
+  end
 end

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -47,13 +47,23 @@ describe Ferrum::Network do
     expect(page.body).to include("test_cookie")
   end
 
-  it "#idle?" do
-    page.go_to("/ferrum/with_slow_ajax_connection")
-    expect(page.at_xpath("//h1[text() = 'Slow AJAX']")).to be
+  describe "#idle?" do
+    it "waits for network to be idle" do
+      page.go_to("/ferrum/with_slow_ajax_connection")
+      expect(page.at_xpath("//h1[text() = 'Slow AJAX']")).to be
 
-    expect(network.idle?).to be_falsey
-    network.wait_for_idle
-    expect(network.idle?).to be_truthy
+      expect(network.idle?).to be_falsey
+      network.wait_for_idle
+      expect(network.idle?).to be_truthy
+    end
+
+    it "does not wait for responses to PING requests" do
+      page.go_to("/ferrum/link_with_ping")
+      page.at_css("a").click
+
+      network.wait_for_idle
+      expect(network.idle?).to be_truthy
+    end
   end
 
   it "#total_connections" do

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -10,6 +10,16 @@ describe Ferrum::Node do
       expect(browser.current_url).to eq(base_url("/"))
     end
 
+    it "fires a ping request for anchor elements" do
+      browser.go_to("/ferrum/link_with_ping")
+
+      expect(browser.network.traffic.length).to eq(1) 
+      browser.at_css("a").click
+
+      # 1 for first load, 1 for load of new url, 1 for ping = 3 total
+      expect(browser.network.traffic.length).to eq(3)
+    end
+
     it "does not run into content quads error" do
       browser.go_to("/ferrum/index")
 

--- a/spec/support/application.rb
+++ b/spec/support/application.rb
@@ -326,6 +326,12 @@ module Ferrum
       params["remaining_path"]
     end
 
+    post "/ferrum/ping" do
+      # Sleeping to simulate a server that does not send a response to PING requests
+      sleep 5
+      halt 204
+    end
+
     protected
 
     def render_view(view)

--- a/spec/support/views/link_with_ping.erb
+++ b/spec/support/views/link_with_ping.erb
@@ -1,0 +1,3 @@
+<p>
+  <a href="/host" ping="/ferrum/ping">Link with ping</a>
+</p>


### PR DESCRIPTION
## Motivation
HTML supports adding a `ping` attribute to `<a>` tags. In such cases, the browser sents a POST request to the set URL(s) before navigating to the new URL (See [w3schools doc here](https://www.w3schools.com/TAGs/att_a_ping.asp) and [Mozilla docs on initiatorType](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/initiatorType) which includes `ping` as an option).
Unfortunately, because these requests do not receive a server response Ferrum adds them to the list of `pending_connections`, meaning that subsequent calls to `wait_for_idle` will timeout waiting for these never-will-complete requests.

## Changes
* Add `Request#response_expected?` method to indicate if the request expects a response from the server (currently 'ping' is the only request I know of that would not get a response)
* Add `Exchange#response_expected?` that calls the request method. Note, if `request.nil?` we default to `true` to match the current behaviour
* Update `Exchange#finished?` so that any requests that do not expect responses are now also considered 'finished'