### PR TITLE
Handle pending connections losing context on frame navigation

### DIFF
--- a/lib/ferrum/network/exchange.rb
+++ b/lib/ferrum/network/exchange.rb
@@ -28,6 +28,12 @@ module Ferrum
       # @return [Error, nil]
       attr_accessor :error
 
+      # Determines if the network exchange is unknown due to
+      # a lost of its context
+      #
+      # @return Boolean
+      attr_accessor :unknown
+
       #
       # Initializes the network exchange.
       #
@@ -40,6 +46,7 @@ module Ferrum
         @page = page
         @intercepted_request = nil
         @request = @response = @error = nil
+        @unknown = false
       end
 
       #
@@ -74,12 +81,12 @@ module Ferrum
 
       #
       # Determines if the request was blocked, a response was returned, or if an
-      # error occurred.
+      # error occurred or the exchange is unknown and cannot be inferred.
       #
       # @return [Boolean]
       #
       def finished?
-        blocked? || response&.loaded? || !error.nil?
+        blocked? || response&.loaded? || !error.nil? || unknown
       end
 
       #
@@ -147,7 +154,8 @@ module Ferrum
           "@intercepted_request=#{@intercepted_request.inspect} " \
           "@request=#{@request.inspect} " \
           "@response=#{@response.inspect} " \
-          "@error=#{@error.inspect}>"
+          "@error=#{@error.inspect}>" \
+          "@unknown=#{@unknown.inspect}>"
       end
     end
   end

--- a/lib/ferrum/network/request.rb
+++ b/lib/ferrum/network/request.rb
@@ -72,6 +72,15 @@ module Ferrum
       end
 
       #
+      # The loader ID of the request.
+      #
+      # @return [String]
+      #
+      def loader_id
+        @params["loaderId"]
+      end
+
+      #
       # The request timestamp.
       #
       # @return [Time]

--- a/lib/ferrum/page/frames.rb
+++ b/lib/ferrum/page/frames.rb
@@ -179,12 +179,16 @@ module Ferrum
           execution_id = params["executionContextId"]
           frame = frame_by(execution_id: execution_id)
           frame&.execution_id = nil
+          frame&.state = :stopped_loading
         end
       end
 
       def subscribe_execution_contexts_cleared
         on("Runtime.executionContextsCleared") do
-          @frames.each_value { |f| f.execution_id = nil }
+          @frames.each_value do |f|
+            f.execution_id = nil
+            f.state = :stopped_loading
+          end
         end
       end
 


### PR DESCRIPTION
# Details
Similar to what is being proposed in #420, this PR fixes intermittent `Ferrum::TimeoutError` as the driver awaits for requests to be completed.

# What
It was observed that in some scenarios the driver is not always receiving and associated `Network.loadingFailed` for requests that were in-flight as the main frame navigates. This may be happening with either main frame requests or sub-frame ones. 

I'm not sure if this is the right approach, but it appears to be working. Basically, it flags requests which are no longer relevant to the current page context as `unknown` which are then assumed to be `#finished`.

Relates to #420