### PR TITLE
chroe: inspect browser classes

### DIFF
--- a/lib/ferrum/browser/client.rb
+++ b/lib/ferrum/browser/client.rb
@@ -70,6 +70,13 @@ module Ferrum
         @thread.kill unless @thread.join(1)
       end
 
+      def inspect
+        "#<#{self.class} " \
+          "@command_id=#{@command_id.inspect} " \
+          "@pendings=#{@pendings.inspect} " \
+          "@ws=#{@ws.inspect}>"
+      end
+
       private
 
       def build_message(method, params)

--- a/lib/ferrum/browser/command.rb
+++ b/lib/ferrum/browser/command.rb
@@ -47,6 +47,10 @@ module Ferrum
         [path] + @flags.map { |k, v| v.nil? ? "--#{k}" : "--#{k}=#{v}" }
       end
 
+      def to_s
+        to_a.join(" \\ \n  ")
+      end
+
       private
 
       def merge_options

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -122,6 +122,17 @@ module Ferrum
         start
       end
 
+      def inspect
+        "#<#{self.class} " \
+          "@user_data_dir=#{@user_data_dir.inspect} " \
+          "@command=#<#{@command.class}:#{@command.object_id}> " \
+          "@default_user_agent=#{@default_user_agent.inspect} " \
+          "@ws_url=#{@ws_url.inspect} " \
+          "@v8_version=#{@v8_version.inspect} " \
+          "@browser_version=#{@browser_version.inspect} " \
+          "@webkit_version=#{@webkit_version.inspect}>"
+      end
+
       private
 
       def kill(pid)


### PR DESCRIPTION
Motivation: this PR adds `#inspect` or `to_s` methods to help debugging when starting browser.