### PR TITLE
ref: Get rid of concurrent async

### DIFF
--- a/.github/gemfiles/websocket-driver-0.6.x.gemfile
+++ b/.github/gemfiles/websocket-driver-0.6.x.gemfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source "https://rubygems.org"
-
-gem "websocket-driver", "~> 0.6.5"
-
-eval_gemfile "../../Gemfile"
-
-gemspec path: "../../"

--- a/.github/gemfiles/websocket-driver-0.7.x.gemfile
+++ b/.github/gemfiles/websocket-driver-0.7.x.gemfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source "https://rubygems.org"
-
-gem "websocket-driver", "~> 0.7.1"
-
-eval_gemfile "../../Gemfile"
-
-gemspec path: "../../"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gemfile: [websocket-driver-0.6.x, websocket-driver-0.7.x]
         ruby: [2.7, "3.0", 3.1, 3.2, 3.3]
     runs-on: ubuntu-latest
     env:
       FERRUM_PROCESS_TIMEOUT: 25
       FERRUM_DEFAULT_TIMEOUT: 15
-      BUNDLE_GEMFILE: .github/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@
 - `Ferrum::Page#screeshot` accepts :area option [#410]
 - Resizing page on creation is gone and moved to Cuprite [#427]
 - Min Ruby version is 2.7
-- Refactored internal API of `Browser`, `Page`, `Context`, `Contexts`, `Target` instead of passing browser and making
-cyclic dependency on the browser instance, we pass now a simple client [#431]
+- Refactored internal API of `Ferrum::Browser`, `Ferrum::Page`, `Ferrum::Context`, `Ferrum::Contexts`, `Ferrum::Target`
+instead of passing browser and making cyclic dependency on the browser instance, we pass now a simple client [#431]
+- Bump `websocket-driver` to `~> 0.7` [#432]
+- Got rid of `Concurrent::Async` in `Ferrum::Browser::Subscriber` [#432]
 
 ### Fixed
+
+- Exceptions within `.on()` were swallowed by a thread pool of `Concurrent::Async` [#432]
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Resizing page on creation is gone and moved to Cuprite [#427]
 - Min Ruby version is 2.7
 - Refactored internal API of `Ferrum::Browser`, `Ferrum::Page`, `Ferrum::Context`, `Ferrum::Contexts`, `Ferrum::Target`
-instead of passing browser and making cyclic dependency on the browser instance, we pass now a simple client [#431]
+instead of passing browser and making cyclic dependency on the browser instance, we pass now a thin client [#431]
 - Bump `websocket-driver` to `~> 0.7` [#432]
 - Got rid of `Concurrent::Async` in `Ferrum::Browser::Subscriber` [#432]
 

--- a/ferrum.gemspec
+++ b/ferrum.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "addressable",      "~> 2.5"
   s.add_runtime_dependency "concurrent-ruby",  "~> 1.1"
   s.add_runtime_dependency "webrick",          "~> 1.7"
-  s.add_runtime_dependency "websocket-driver", ">= 0.6", "< 0.8"
+  s.add_runtime_dependency "websocket-driver", "~> 0.7"
 end

--- a/lib/ferrum.rb
+++ b/lib/ferrum.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "ferrum/utils/thread"
 require "ferrum/utils/platform"
 require "ferrum/utils/elapsed_time"
 require "ferrum/utils/attempt"

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -208,6 +208,7 @@ module Ferrum
     def quit
       return unless @client
 
+      contexts.close_connections
       @client.close
       @process.stop
       @client = @process = @contexts = nil

--- a/lib/ferrum/browser/web_socket.rb
+++ b/lib/ferrum/browser/web_socket.rb
@@ -52,6 +52,7 @@ module Ferrum
 
       def on_close(_event)
         @messages.close
+        @sock.close
         @thread.kill
       end
 
@@ -65,7 +66,7 @@ module Ferrum
 
       def write(data)
         @sock.write(data)
-      rescue EOFError, Errno::ECONNRESET, Errno::EPIPE
+      rescue EOFError, Errno::ECONNRESET, Errno::EPIPE, IOError # rubocop:disable Lint/ShadowedException
         @messages.close
       end
 
@@ -83,7 +84,7 @@ module Ferrum
 
             @driver.parse(data)
           end
-        rescue EOFError, Errno::ECONNRESET, Errno::EPIPE
+        rescue EOFError, Errno::ECONNRESET, Errno::EPIPE, IOError # rubocop:disable Lint/ShadowedException
           @messages.close
         end
       end

--- a/lib/ferrum/context.rb
+++ b/lib/ferrum/context.rb
@@ -71,6 +71,14 @@ module Ferrum
       @targets.delete(target_id)
     end
 
+    def close_targets_connection
+      @targets.each_value do |target|
+        next unless target.attached?
+
+        target.page.close_connection
+      end
+    end
+
     def dispose
       @contexts.dispose(@id)
     end

--- a/lib/ferrum/context.rb
+++ b/lib/ferrum/context.rb
@@ -64,7 +64,7 @@ module Ferrum
     end
 
     def update_target(target_id, params)
-      @targets[target_id].update(params)
+      @targets[target_id]&.update(params)
     end
 
     def delete_target(target_id)

--- a/lib/ferrum/contexts.rb
+++ b/lib/ferrum/contexts.rb
@@ -45,9 +45,14 @@ module Ferrum
 
     def dispose(context_id)
       context = @contexts[context_id]
+      context.close_targets_connection
       @client.command("Target.disposeBrowserContext", browserContextId: context.id)
       @contexts.delete(context_id)
       true
+    end
+
+    def close_connections
+      @contexts.each_value(&:close_targets_connection)
     end
 
     def reset

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -120,7 +120,13 @@ module Ferrum
     def close
       @headers.clear
       client(browser: true).command("Target.closeTarget", targetId: @target_id)
-      @page_client.close
+      close_connection
+
+      true
+    end
+
+    def close_connection
+      @page_client&.close
     end
 
     #

--- a/lib/ferrum/page/frames.rb
+++ b/lib/ferrum/page/frames.rb
@@ -134,7 +134,7 @@ module Ferrum
           end
 
           frame = @frames[params["frameId"]]
-          frame.state = :stopped_loading
+          frame&.state = :stopped_loading
 
           @event.set if idling?
         end

--- a/lib/ferrum/proxy.rb
+++ b/lib/ferrum/proxy.rb
@@ -52,7 +52,7 @@ module Ferrum
     end
 
     def stop
-      @file&.unlink
+      @file&.close(true)
       @server.shutdown
     end
 

--- a/lib/ferrum/utils/thread.rb
+++ b/lib/ferrum/utils/thread.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Ferrum
+  module Utils
+    module Thread
+      module_function
+
+      def spawn(abort_on_exception: true)
+        ::Thread.new(abort_on_exception) do
+          ::Thread.current.abort_on_exception = abort_on_exception
+          ::Thread.current.report_on_exception = true if ::Thread.current.respond_to?(:report_on_exception=)
+
+          yield
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
   end
 
   config.after(:all) do
-    @browser.quit
+    @browser&.quit
   end
 
   config.before(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
   end
 
   config.after(:all) do
-    @browser&.quit
+    @browser.quit
   end
 
   config.before(:each) do


### PR DESCRIPTION
We can easily workaround async with queue and a thread and btw simplify the subscriber. Swallowing errors is not good, closes #395, #396