### PR TITLE
Improve Mac ARM (Apple Silicon) support

### DIFF
--- a/lib/ferrum/browser/options/chrome.rb
+++ b/lib/ferrum/browser/options/chrome.rb
@@ -6,7 +6,6 @@ module Ferrum
       class Chrome < Base
         DEFAULT_OPTIONS = {
           "headless" => nil,
-          "disable-gpu" => nil,
           "hide-scrollbars" => nil,
           "mute-audio" => nil,
           "enable-automation" => nil,
@@ -43,7 +42,18 @@ module Ferrum
           # NOTE: --no-sandbox is not needed if you properly setup a user in the container.
           # https://github.com/ebidel/lighthouse-ci/blob/master/builder/Dockerfile#L35-L40
           # "no-sandbox" => nil,
-        }.freeze
+        }
+        # On Windows, the --disable-gpu flag is a temporary work around for a few bugs.
+        # See crbug.com/737678 for more information.
+        if Utils::Platform.windows?
+          DEFAULT_OPTIONS.merge!("disable-gpu" => nil)
+        end
+        # Use Metal on Apple Silicon
+        # https://github.com/google/angle#platform-support-via-backing-renderers
+        if Utils::Platform.mac_arm?
+          DEFAULT_OPTIONS.merge!("use-angle" => "metal")
+        end
+        DEFAULT_OPTIONS.freeze
 
         MAC_BIN_PATH = [
           "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",

--- a/lib/ferrum/utils/platform.rb
+++ b/lib/ferrum/utils/platform.rb
@@ -20,6 +20,10 @@ module Ferrum
         RbConfig::CONFIG["host_os"] =~ /darwin/
       end
 
+      def mac_arm?
+        mac? && RbConfig::CONFIG["host_cpu"] =~ /arm/
+      end
+
       def mri?
         defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby"
       end

--- a/spec/browser/options/chrome_spec.rb
+++ b/spec/browser/options/chrome_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe Ferrum::Browser::Options::Chrome do
+  def reload_chrome_class
+    described_class.constants(false).each do |const|
+      described_class.send(:remove_const, const)
+    end
+    load 'ferrum/browser/options/chrome.rb'
+  end
+
+  describe "DEFAULT_OPTIONS" do
+    it "includes `disable-gpu` flag only on windows" do
+      allow(Ferrum::Utils::Platform).to receive(:windows?).and_return(true)
+      reload_chrome_class
+      expect(described_class::DEFAULT_OPTIONS).to include("disable-gpu" => nil)
+
+      allow(Ferrum::Utils::Platform).to receive(:windows?).and_return(false)
+      reload_chrome_class
+      expect(described_class::DEFAULT_OPTIONS).not_to include("disable-gpu" => nil)
+
+      allow(Ferrum::Utils::Platform).to receive(:windows?).and_call_original
+      reload_chrome_class
+    end
+
+    it "includes `use-angle=metal` flag only on mac arm" do
+      allow(Ferrum::Utils::Platform).to receive(:mac_arm?).and_return(true)
+      reload_chrome_class
+      expect(described_class::DEFAULT_OPTIONS).to include("use-angle" => "metal")
+
+      allow(Ferrum::Utils::Platform).to receive(:mac_arm?).and_return(false)
+      reload_chrome_class
+      expect(described_class::DEFAULT_OPTIONS).not_to include("use-angle" => "metal")
+
+      allow(Ferrum::Utils::Platform).to receive(:mac_arm?).and_call_original
+      reload_chrome_class
+    end
+  end
+end


### PR DESCRIPTION
This patch aims to close the issue #421 by doing the following:

1. Only include the `--disable-gpu` flag when running on Windows as it is not needed on other platforms and it causes issues on Mac ARM.
2. Adding the `--use-angle=metal` flag when running on Mac ARM so the browser uses the Metal API instead of OpenGL.

Close #421