### PR TITLE
Better handling of ws_url, and avoid stripping query params from url

### DIFF
--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -64,11 +64,9 @@ module Ferrum
 
         if options.ws_url
           response = parse_json_version(options.ws_url)
-          self.ws_url = response&.[]("webSocketDebuggerUrl") || options.ws_url
+          self.ws_url = options.ws_url
           return
-        end
-
-        if options.url
+        elsif options.url
           response = parse_json_version(options.url)
           self.ws_url = response&.[]("webSocketDebuggerUrl")
           return
@@ -187,10 +185,11 @@ module Ferrum
       end
 
       def parse_json_version(url)
-        url = URI.join(url, "/json/version")
+        uri = Addressable::URI.parse(url)
+        uri.path = "/json/version"
 
-        if %w[wss ws].include?(url.scheme)
-          url.scheme = case url.scheme
+        if %w[wss ws].include?(uri.scheme)
+          uri.scheme = case uri.scheme
                        when "ws"
                          "http"
                        when "wss"
@@ -198,7 +197,7 @@ module Ferrum
                        end
         end
 
-        response = JSON.parse(::Net::HTTP.get(URI(url.to_s)))
+        response = JSON.parse(::Net::HTTP.get(URI(uri.to_s)))
 
         @v8_version = response["V8-Version"]
         @browser_version = response["Browser"]


### PR DESCRIPTION
Hi,

This fixes some compatibility issues with [browserless](https://github.com/browserless/browserless) v2 and possibly others.

An issue with the `parse_json_version` was that it would turn the ws scheme into http, strip query params and request /json/version. This is the first problem, stripping query params which often include an auth token and other configuration.

The second concern was that the `initializer` would override the ws_url based on what that endpoint would show, in the case of browserless that would be 0.0.0.0:3000. If the ws_url has been set, ferrum should not try to override that.

This is my first OSS PR so I am sorry if I did some thing wrong.

#439 