### PR TITLE
Gracefully shutdown the browser on `.quit`

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -211,6 +211,8 @@ module Ferrum
     def quit
       return unless @client
 
+      
+      command('Browser.close')
       contexts.close_connections
 
       @client.close

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -211,8 +211,11 @@ module Ferrum
     def quit
       return unless @client
 
-      
-      command('Browser.close')
+      begin
+        command('Browser.close')
+      rescue
+      end
+
       contexts.close_connections
 
       @client.close


### PR DESCRIPTION
Fixes #418 - https://github.com/rubycdp/ferrum/issues/418#issuecomment-1960822066

In my application, I found that my sessions to my Browserless server were staying open after I called .quit. When I invoke this command, the sessions more gracefully exit and the server gives back its resources.