### PR TITLE
fix: Broken escaped unicode crashes JSON parser

### DIFF
--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -396,6 +396,27 @@ describe Ferrum::Node do
       expect(el.text).to eq("FooBar")
     end
 
+    it "works with valid utf8" do
+      browser.go_to("/unicode")
+      el = browser.at_css("#valid")
+
+      expect(el.text).to eq("Havregrynskake med marengs og nøtter 😍 såå god!")
+    end
+
+    it "works with invalid utf8" do
+      browser.go_to("/unicode")
+      el = browser.at_css("#invalid")
+
+      expect(el.text).to eq("Havregrynskake med marengs og nøtter ???")
+    end
+
+    it "works with curly utf8" do
+      browser.go_to("/unicode")
+      el = browser.at_css("#curly")
+
+      expect(el.text).to eq("😀 and ☀")
+    end
+
     context "SVG tests" do
       before do
         browser.go_to("/ferrum/svg_test")

--- a/spec/support/application.rb
+++ b/spec/support/application.rb
@@ -188,6 +188,10 @@ module Ferrum
       send_file("attachment.pdf")
     end
 
+    get "/unicode" do
+      File.read("#{FERRUM_VIEWS}/unicode.html")
+    end
+
     get "/:view" do |view|
       erb view.to_sym, locals: { referrer: request.referrer }
     end

--- a/spec/support/views/unicode.html
+++ b/spec/support/views/unicode.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <p>
+      <span id="valid"></span>
+    </p>
+    <p>
+      <span id="invalid"></span>
+    </p>
+    <p>
+      <span id="curly"></span>
+    </p>
+    <script>
+      document.getElementById('invalid').innerHTML = "Havregrynskake med marengs og n\u00f8tter \ud83d"
+      document.getElementById('valid').innerHTML = "Havregrynskake med marengs og nøtter \ud83d\ude0d såå god!"
+      document.getElementById('curly').innerHTML = "\u{1F600} and \u{2600}"
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Assigning broken unicode to a node directly from JS can lead to `JSON::ParserError: incomplete surrogate pair at ...` error. We try to unescape unicode code points and replace invalid ones with `?` char now. If still after that JSON cannot parse the string, we raise error. That's anyways the best we can do, we can't just skip CDP message.