### PR TITLE
fix: Support all Ruby 2.7 for now

### DIFF
--- a/lib/ferrum/client.rb
+++ b/lib/ferrum/client.rb
@@ -34,8 +34,8 @@ module Ferrum
       @client.respond_to?(name, include_private)
     end
 
-    def method_missing(name, ...)
-      @client.send(name, ...)
+    def method_missing(name, *args, **opts, &block)
+      @client.send(name, *args, **opts, &block)
     end
 
     def close


### PR DESCRIPTION
Ruby syntax `...` was added not for all 2.7 versions. Let's fallback for now to old syntax.