### PR TITLE
Allow subscriptions to be removed

### DIFF
--- a/lib/ferrum/client.rb
+++ b/lib/ferrum/client.rb
@@ -26,6 +26,10 @@ module Ferrum
       @client.on(event_name(event), &block)
     end
 
+    def off(event, id)
+      @client.off(event_name(event), id)
+    end
+
     def subscribed?(event)
       @client.subscribed?(event_name(event))
     end
@@ -97,6 +101,10 @@ module Ferrum
 
     def on(event, &block)
       @subscriber.on(event, &block)
+    end
+
+    def off(event, id)
+      @subscriber.off(event, id)
     end
 
     def subscribed?(event)

--- a/lib/ferrum/client/subscriber.rb
+++ b/lib/ferrum/client/subscriber.rb
@@ -23,6 +23,11 @@ module Ferrum
 
       def on(event, &block)
         @on[event] << block
+        @on[event].index(block)
+      end
+
+      def off(event, id)
+        @on[event].delete_at(id)
         true
       end
 

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -379,6 +379,19 @@ module Ferrum
       end
     end
 
+    def off(name, id)
+      case name
+      when :dialog
+        client.off("Page.javascriptDialogOpening", id)
+      when :request
+        client.off("Fetch.requestPaused", id)
+      when :auth
+        client.off("Fetch.authRequired", id)
+      else
+        client.off(name, id)
+      end
+    end
+
     def subscribed?(event)
       client.subscribed?(event)
     end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -194,4 +194,42 @@ describe Ferrum::Page do
       expect(page.device_pixel_ratio).to eq(2)
     end
   end
+
+  describe "#on" do
+    it "subscribes to an event" do
+      message = nil
+
+      page.on("Runtime.consoleAPICalled") do |params|
+        message = params.dig("args", 0, "value")
+      end
+
+      page.evaluate("console.log('hello')")
+      expect(message).to eq("hello")
+    end
+  end
+
+  describe "#off" do
+    it "unsubscribes a specific event handler" do
+      message_a = nil
+      message_b = nil
+
+      a = page.on("Runtime.consoleAPICalled") do |params|
+        message_a = params.dig("args", 0, "value")
+      end
+
+      page.on("Runtime.consoleAPICalled") do |params|
+        message_b = params.dig("args", 0, "value")
+      end
+
+      page.evaluate("console.log('hello')")
+      expect(message_a).to eq("hello")
+      expect(message_b).to eq("hello")
+
+      page.off("Runtime.consoleAPICalled", a)
+      page.evaluate("console.log('goodbye')")
+
+      expect(message_a).to eq("hello")
+      expect(message_b).to eq("goodbye")
+    end
+  end
 end


### PR DESCRIPTION
This is admittedly not the most elegant API, but my goal is to start a discussion about how this should look.

Here's how you'd subscribe and unsubscribe:
```ruby
subscription = page.on("Some.event") do |params, _index, _total|
  # etc
end

page.off("Some.event", subscription)
```

Here are some important considerations:
* The `#on` method previously returned `true`. Now, it returns the index of the block within `@on[event]`. This could be considered a breaking change. Rather than using `#on` and `#off`, we could introduce a new method called `#subscribe`.
* Rather than returning a value that identifies the specific event handler, we could return an object that has an `#unsubscribe` method.