### PR TITLE
Require missing dependencies

### DIFF
--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -9,6 +9,8 @@ require "ferrum/browser/options/base"
 require "ferrum/browser/options/chrome"
 require "ferrum/browser/options/firefox"
 require "ferrum/browser/command"
+require "ferrum/utils/elapsed_time"
+require "ferrum/utils/platform"
 
 module Ferrum
   class Browser

--- a/lib/ferrum/client.rb
+++ b/lib/ferrum/client.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require "concurrent-ruby"
 require "forwardable"
 require "ferrum/client/subscriber"
 require "ferrum/client/web_socket"
+require "ferrum/utils/thread"
 
 module Ferrum
   class SessionClient


### PR DESCRIPTION
I intend to `require 'ferrum/browser` to start a browser. However, `ferrum/browser.rb` misses a few dependencies. I add them in this PR. This PR doesn't fix other ruby files though.