### PR TITLE
Fixed a broken JSON in log output

### DIFF
--- a/lib/ferrum/client/web_socket.rb
+++ b/lib/ferrum/client/web_socket.rb
@@ -63,7 +63,7 @@ module Ferrum
         output = event.data
         if SKIP_LOGGING_SCREENSHOTS && @screenshot_commands[data["id"]]
           @screenshot_commands.delete(data["id"])
-          output.sub!(/{"data":"(.*)"}/, %("Set FERRUM_LOGGING_SCREENSHOTS=true to see screenshots in Base64"))
+          output.sub!(/{"data":"[^"]*"}/, %("Set FERRUM_LOGGING_SCREENSHOTS=true to see screenshots in Base64"))
         end
 
         @logger&.puts("    ◀ #{Utils::ElapsedTime.elapsed_time} #{output}\n")


### PR DESCRIPTION
Since v0.15, a JSON format in the log output has been broken. When the original log is in the following format:

```
"{\"id\":27,\"result\":{\"data\":\"(snipped)\"},\"sessionId\":\"E2C753A9154794C390311B8647590A03\"}"
```

It gets converted to a format without a closing } like this:

```
"    ◀ 10.680710212999657 {\"id\":27,\"result\":\"Set FERRUM_LOGGING_SCREENSHOTS=true to see screenshots in Base64\"\n"
```

Upon investigation, I found that the string replacement performed when SKIP_LOGGING_SCREENSHOTS is enabled was unintentionally breaking the JSON format. Therefore, I modified the regular expression used for the replacement.