### PR TITLE
Allow using default browser context

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -125,6 +125,9 @@ module Ferrum
     # @option options [Hash] :env
     #   Environment variables you'd like to pass through to the process.
     #
+    # @option options [Boolean] :use_default_context
+    #   When true, allows using the default browser context that has access to the browser's persistent state.
+    #
     def initialize(options = nil)
       @options = Options.new(options)
       @client = @process = @contexts = nil

--- a/lib/ferrum/browser/options.rb
+++ b/lib/ferrum/browser/options.rb
@@ -15,7 +15,7 @@ module Ferrum
                   :js_errors, :base_url, :slowmo, :pending_connection_errors,
                   :url, :ws_url, :env, :process_timeout, :browser_name, :browser_path,
                   :save_path, :proxy, :port, :host, :headless, :browser_options,
-                  :ignore_default_browser_options, :xvfb, :flatten
+                  :ignore_default_browser_options, :xvfb, :flatten, :use_default_context
       attr_accessor :timeout, :default_user_agent
 
       def initialize(options = nil)
@@ -45,6 +45,7 @@ module Ferrum
         @base_url = parse_base_url(@options[:base_url]) if @options[:base_url]
         @url = @options[:url].to_s if @options[:url]
         @ws_url = @options[:ws_url].to_s if @options[:ws_url]
+        @use_default_context = @options.fetch(:use_default_context, false)
 
         @options = @options.merge(window_size: @window_size).freeze
         @browser_options = @options.fetch(:browser_options, {}).freeze

--- a/lib/ferrum/context.rb
+++ b/lib/ferrum/context.rb
@@ -46,7 +46,8 @@ module Ferrum
     end
 
     def create_target
-      @client.command("Target.createTarget", browserContextId: @id, url: "about:blank")
+      target_params = {browserContextId: @id, url: "about:blank"}.compact
+      @client.command("Target.createTarget", **target_params)
       target = @pendings.take(@client.timeout)
       raise NoSuchTargetError unless target.is_a?(Target)
 

--- a/lib/ferrum/context.rb
+++ b/lib/ferrum/context.rb
@@ -46,7 +46,7 @@ module Ferrum
     end
 
     def create_target
-      target_params = {browserContextId: @id, url: "about:blank"}.compact
+      target_params = { browserContextId: @id, url: "about:blank" }.compact
       @client.command("Target.createTarget", **target_params)
       target = @pendings.take(@client.timeout)
       raise NoSuchTargetError unless target.is_a?(Target)

--- a/lib/ferrum/contexts.rb
+++ b/lib/ferrum/contexts.rb
@@ -24,7 +24,7 @@ module Ferrum
     def create_default_context
       default_context_id = compute_default_context_id
       # Targets created in this context will not be created with a browserContextId
-      @contexts[default_context_id] = ::Ferrum::Context.new(@client, self, nil)
+      @contexts[default_context_id] = Context.new(@client, self, nil)
     end
 
     # Compute the default context ID by looking for contexts not returned by Target.getBrowserContexts

--- a/lib/ferrum/contexts.rb
+++ b/lib/ferrum/contexts.rb
@@ -11,7 +11,7 @@ module Ferrum
     def initialize(client)
       @contexts = Concurrent::Map.new
       @client = client
-      @default_context = create_default_context
+      @default_context = create_default_context if @client.options.use_default_context
       subscribe
       auto_attach
       discover


### PR DESCRIPTION
This PR adds an option for Ferrum to use the default browser context instead of a created BrowserContext that doesn't have access to the persisted browser state.

I know that historically for testing purposes it's been recommended here to use clean browser contexts for reproducibility, but I think this is a reasonable option for some use cases (that may not be related to testing). Other similar libraries provide such options. For example, Playwright lets you do [launchPersistentContext](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-persistent-context) to launch a browser with a persistent context. Puppeteer seems to default to using the default browser context and [only creates new BrowserContexts if you manually create them](https://pptr.dev/guides/browser-management#browser-contexts). I don't have experience with these libraries, but I did a lot of digging through their source to see how they handled Target creation and BrowserContext creation.

Fixes https://github.com/rubycdp/ferrum/issues/47

Re: this comment from that thread:

> I think the default context that Chrome creates has a lot of limitations like inability to create pages inside it and so on.

I seem to be able to create pages/targets within the default context fine. However, I haven't explored much so there could very well be bugs associated with this change. All I know is that it works for my use case and it would be very useful to have this in the upstream gem. I'm happy to discuss whether this change makes sense or not and I don't mind if the answer is that it doesn't. But at least in my case, the save/load cookies feature from 99cfa84c56e55bb373da48935d08d5a13df1ad27 doesn't solve my use case because the persisted browser state that I'm trying to restore is coming from a browser hosting service (https://www.browserbase.com/), so the only way I can access the state is through the browser's default context.

Thank you for your consideration!