### PR TITLE
Add base64 to runtime dependencies for Ruby 3.4 compatibility

### DIFF
--- a/ferrum.gemspec
+++ b/ferrum.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7.0"
 
   s.add_runtime_dependency "addressable",      "~> 2.5"
+  s.add_runtime_dependency "base64",           "~> 0.2"
   s.add_runtime_dependency "concurrent-ruby",  "~> 1.1"
   s.add_runtime_dependency "webrick",          "~> 1.7"
   s.add_runtime_dependency "websocket-driver", "~> 0.7"

--- a/ferrum.gemspec
+++ b/ferrum.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
 
-  s.add_runtime_dependency "addressable",      "~> 2.5"
-  s.add_runtime_dependency "base64",           "~> 0.2"
-  s.add_runtime_dependency "concurrent-ruby",  "~> 1.1"
-  s.add_runtime_dependency "webrick",          "~> 1.7"
-  s.add_runtime_dependency "websocket-driver", "~> 0.7"
+  s.add_dependency "addressable",      "~> 2.5"
+  s.add_dependency "base64",           "~> 0.2"
+  s.add_dependency "concurrent-ruby",  "~> 1.1"
+  s.add_dependency "webrick",          "~> 1.7"
+  s.add_dependency "websocket-driver", "~> 0.7"
 end


### PR DESCRIPTION
See https://github.com/ruby/ruby/blob/master/doc/NEWS/NEWS-3.3.0.md#stdlib-updates

With Ruby 3.4 on forward, `base64` will no longer be available as part of part of the default gems. It needs to be an explicit dependency going forward.