### PR TITLE
Improve thread scheduling

### DIFF
--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -16,7 +16,6 @@ module Ferrum
   class Browser
     class Process
       KILL_TIMEOUT = 2
-      WAIT_KILLED = 0.05
 
       attr_reader :host, :port, :ws_url, :pid, :command,
                   :default_user_agent, :browser_version, :protocol_version,
@@ -38,7 +37,7 @@ module Ferrum
             ::Process.kill("USR1", pid)
             start = Utils::ElapsedTime.monotonic_time
             while ::Process.wait(pid, ::Process::WNOHANG).nil?
-              sleep(WAIT_KILLED)
+              ::Thread.pass
               next unless Utils::ElapsedTime.timeout?(start, KILL_TIMEOUT)
 
               ::Process.kill("KILL", pid)

--- a/lib/ferrum/network.rb
+++ b/lib/ferrum/network.rb
@@ -46,9 +46,6 @@ module Ferrum
     # @param [Integer] connections
     #   how many connections are allowed for network to be idling,
     #
-    # @param [Float] duration
-    #   Sleep for given amount of time and check again.
-    #
     # @param [Float] timeout
     #   During what time we try to check idle.
     #
@@ -59,13 +56,13 @@ module Ferrum
     #   browser.at_xpath("//a[text() = 'No UI changes button']").click
     #   browser.network.wait_for_idle # => false
     #
-    def wait_for_idle(connections: 0, duration: 0.05, timeout: @page.timeout)
+    def wait_for_idle(connections: 0, timeout: @page.timeout)
       start = Utils::ElapsedTime.monotonic_time
 
       until idle?(connections)
         return false if Utils::ElapsedTime.timeout?(start, timeout)
 
-        sleep(duration)
+        ::Thread.pass
       end
 
       true

--- a/lib/ferrum/utils/attempt.rb
+++ b/lib/ferrum/utils/attempt.rb
@@ -13,7 +13,7 @@ module Ferrum
 
         attempts += 1
         ::Thread.pass
-        sleep(wait) if wait <= 0.1
+        sleep(wait)
 
         retry
       end

--- a/lib/ferrum/utils/attempt.rb
+++ b/lib/ferrum/utils/attempt.rb
@@ -12,9 +12,9 @@ module Ferrum
         raise if attempts >= max
 
         attempts += 1
-        ::Thread.pass
         sleep(wait)
 
+        ::Thread.pass
         retry
       end
     end

--- a/lib/ferrum/utils/attempt.rb
+++ b/lib/ferrum/utils/attempt.rb
@@ -12,7 +12,9 @@ module Ferrum
         raise if attempts >= max
 
         attempts += 1
-        sleep(wait)
+        ::Thread.pass
+        sleep(wait) if wait <= 0.1
+
         retry
       end
     end

--- a/lib/ferrum/utils/event.rb
+++ b/lib/ferrum/utils/event.rb
@@ -17,8 +17,6 @@ module Ferrum
 
       def wait(timeout)
         ::Thread.pass
-        return if timeout <= 0.1
-
         super
       end
     end

--- a/lib/ferrum/utils/event.rb
+++ b/lib/ferrum/utils/event.rb
@@ -14,6 +14,12 @@ module Ferrum
           @iteration
         end
       end
+
+      def wait(timeout)
+        return ::Thread.pass if timeout <= 0.1
+
+        super
+      end
     end
   end
 end

--- a/lib/ferrum/utils/event.rb
+++ b/lib/ferrum/utils/event.rb
@@ -16,8 +16,17 @@ module Ferrum
       end
 
       def wait(timeout)
-        ::Thread.pass
-        super
+        synchronize do
+          unless @set
+            iteration = @iteration
+            ns_wait_until(timeout) do
+              iteration < @iteration || @set
+              ::Thread.pass
+            end
+          else
+            true
+          end
+        end
       end
     end
   end

--- a/lib/ferrum/utils/event.rb
+++ b/lib/ferrum/utils/event.rb
@@ -16,7 +16,8 @@ module Ferrum
       end
 
       def wait(timeout)
-        return ::Thread.pass if timeout <= 0.1
+        ::Thread.pass
+        return if timeout <= 0.1
 
         super
       end


### PR DESCRIPTION
use Thread.pass where ever possible, because ferrum scrapers usually are put in sidekiq workers and it's better to yield to other threads that actually do work instead of waiting
https://github.com/sidekiq/sidekiq/discussions/5039

and `wait_for_idle(..duration:)` the duration param is not really set by someone duration:, only the timeout value is usually set