### PR TITLE
Add screencast functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,56 @@ page.go_to("https://google.com/")
 page.mhtml(path: "google.mhtml") # => 87742
 ```
 
+## Screencast
+
+#### start_screencast(\*\*options) {|data, metadata, session_id| block }
+
+Starts sending each frame to the given block.
+
+* options `Hash`
+  * :format `Symbol` `:jpeg` | `:png` The format the image should be returned in.
+  * :quality `Integer` The image quality. **Note:** 0-100 works for JPEG only.
+  * :max_width `Integer` Maximum screencast frame width.
+  * :max_height `Integer` Maximum screencast frame height.
+  * :every_nth_frame `Integer` Send every n-th frame.
+
+* Block inputs:
+  * data `String` Base64-encoded compressed image.
+  * metadata `Hash` Screencast frame metadata.
+    * 'offsetTop' `Integer` Top offset in DIP.
+    * 'pageScaleFactor' `Integer` Page scale factor.
+    * 'deviceWidth' `Integer` Device screen width in DIP.
+    * 'deviceHeight' `Integer` Device screen height in DIP.
+    * 'scrollOffsetX' `Integer` Position of horizontal scroll in CSS pixels.
+    * 'scrollOffsetY' `Integer` Position of vertical scroll in CSS pixels.
+    * 'timestamp' `Float` (optional) Frame swap timestamp in seconds since Unix epoch.
+  * session_id `Integer` Frame number.
+
+```ruby
+require 'base64'
+
+page.go_to("https://apple.com/ipad")
+
+page.start_screencast(format: :jpeg, quality: 75) do |data, metadata|
+  timestamp_ms = metadata['timestamp'] * 1000
+  File.open("image_#{timestamp_ms.to_i}.jpg", 'wb') do
+    _1.write(Base64.decode64 data)
+  end
+end
+
+sleep 10
+
+page.stop_screencast
+```
+
+> ### 📝 NOTE
+> 
+> Chrome only sends new frames while page content is changing. For example, if
+> there is an animation or a video on the page, Chrome sends frames at the rate
+> requested. On the other hand, if the page is nothing but a wall of static text,
+> Chrome sends frames while the page renders. Once Chrome has finished rendering
+> the page, it sends no more frames until something changes (e.g., navigating to
+> another location).
 
 ## Network
 

--- a/README.md
+++ b/README.md
@@ -493,9 +493,7 @@ page.go_to("https://apple.com/ipad")
 
 page.start_screencast(format: :jpeg, quality: 75) do |data, metadata|
   timestamp_ms = metadata['timestamp'] * 1000
-  File.open("image_#{timestamp_ms.to_i}.jpg", 'wb') do
-    _1.write(Base64.decode64 data)
-  end
+  File.binwrite("image_#{timestamp_ms.to_i}.jpg", Base64.decode64(data))
 end
 
 sleep 10

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -23,6 +23,7 @@ module Ferrum
                 headers cookies network downloads
                 mouse keyboard
                 screenshot pdf mhtml viewport_size device_pixel_ratio
+                start_screencast stop_screencast
                 frames frame_by main_frame
                 evaluate evaluate_on evaluate_async execute evaluate_func
                 add_script_tag add_style_tag bypass_csp

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -10,6 +10,7 @@ require "ferrum/dialog"
 require "ferrum/network"
 require "ferrum/downloads"
 require "ferrum/page/frames"
+require "ferrum/page/screencast"
 require "ferrum/page/screenshot"
 require "ferrum/page/animation"
 require "ferrum/page/tracing"
@@ -27,6 +28,7 @@ module Ferrum
     delegate %i[base_url default_user_agent timeout timeout=] => :@options
 
     include Animation
+    include Screencast
     include Screenshot
     include Frames
     include Stream

--- a/lib/ferrum/page/screencast.rb
+++ b/lib/ferrum/page/screencast.rb
@@ -3,7 +3,6 @@
 module Ferrum
   class Page
     module Screencast
-
       # Starts yielding each frame to the given block.
       #
       # @param [Hash{Symbol => Object}] opts
@@ -64,9 +63,7 @@ module Ferrum
       #
       #   page.start_screencast(format: :jpeg, quality: 75) do |data, metadata|
       #     timestamp_ms = metadata['timestamp'] * 1000
-      #     File.open("image_#{timestamp_ms.to_i}.jpg", 'wb') do
-      #       _1.write(Base64.decode64 data)
-      #     end
+      #     File.binwrite("image_#{timestamp_ms.to_i}.jpg", Base64.decode64(data))
       #   end
       #
       #   sleep 10
@@ -74,18 +71,17 @@ module Ferrum
       #   page.stop_screencast
       #
       def start_screencast(**opts)
-
         options = opts.transform_keys { START_SCREENCAST_KEY_CONV.fetch(_1, _1) }
-        response = command('Page.startScreencast', **options)
+        response = command("Page.startScreencast", **options)
 
-        if error_text = response["errorText"] # https://cs.chromium.org/chromium/src/net/base/net_error_list.h
+        if (error_text = response["errorText"]) # https://cs.chromium.org/chromium/src/net/base/net_error_list.h
           raise "Starting screencast failed (#{error_text})"
         end
 
-        on('Page.screencastFrame') do |params|
-          data, metadata, session_id = params.values_at('data', 'metadata', 'sessionId')
+        on("Page.screencastFrame") do |params|
+          data, metadata, session_id = params.values_at("data", "metadata", "sessionId")
 
-          command('Page.screencastFrameAck', sessionId: session_id)
+          command("Page.screencastFrameAck", sessionId: session_id)
 
           yield data, metadata, session_id
         end
@@ -93,15 +89,13 @@ module Ferrum
 
       # Stops sending each frame.
       def stop_screencast
-        command('Page.stopScreencast')
+        command("Page.stopScreencast")
       end
 
-    private
-
       START_SCREENCAST_KEY_CONV = {
-        max_width:       :maxWidth,
-        max_height:      :maxHeight,
-        every_nth_frame: :everyNthFrame,
+        max_width: :maxWidth,
+        max_height: :maxHeight,
+        every_nth_frame: :everyNthFrame
       }.freeze
     end
   end

--- a/lib/ferrum/page/screencast.rb
+++ b/lib/ferrum/page/screencast.rb
@@ -12,16 +12,66 @@ module Ferrum
       #   The format the image should be returned in.
       #
       # @option opts [Integer] :quality
-      #   The image quality. **Note:** 0-100 works for jpeg only.
+      #   The image quality. **Note:** 0-100 works for JPEG only.
       #
       # @option opts [Integer] :max_width
-      #   Maximum screenshot width.
+      #   Maximum screencast frame width.
       #
       # @option opts [Integer] :max_height
-      #   Maximum screenshot height.
+      #   Maximum screencast frame height.
       #
       # @option opts [Integer] :every_nth_frame
       #   Send every n-th frame.
+      #
+      # @yield [data, metadata, session_id]
+      #   The given block receives the screencast frame along with metadata
+      #   about the frame and the screencast session ID.
+      #
+      # @yieldparam data [String]
+      #   Base64-encoded compressed image.
+      #
+      # @yieldparam metadata [Hash{String => Object}]
+      #   Screencast frame metadata.
+      #
+      # @option metadata [Integer] 'offsetTop'
+      #   Top offset in DIP.
+      #
+      # @option metadata [Integer] 'pageScaleFactor'
+      #   Page scale factor.
+      #
+      # @option metadata [Integer] 'deviceWidth'
+      #   Device screen width in DIP.
+      #
+      # @option metadata [Integer] 'deviceHeight'
+      #   Device screen height in DIP.
+      #
+      # @option metadata [Integer] 'scrollOffsetX'
+      #   Position of horizontal scroll in CSS pixels.
+      #
+      # @option metadata [Integer] 'scrollOffsetY'
+      #   Position of vertical scroll in CSS pixels.
+      #
+      # @option metadata [Float] 'timestamp'
+      #   (optional) Frame swap timestamp in seconds since Unix epoch.
+      #
+      # @yieldparam session_id [Integer]
+      #   Frame number.
+      #
+      # @example
+      #   require 'base64'
+      #
+      #   page.go_to("https://apple.com/ipad")
+      #
+      #   page.start_screencast(format: :jpeg, quality: 75) do |data, metadata|
+      #     timestamp_ms = metadata['timestamp'] * 1000
+      #     File.open("image_#{timestamp_ms.to_i}.jpg", 'wb') do
+      #       _1.write(Base64.decode64 data)
+      #     end
+      #   end
+      #
+      #   sleep 10
+      #
+      #   page.stop_screencast
       #
       def start_screencast(**opts)
 

--- a/lib/ferrum/page/screencast.rb
+++ b/lib/ferrum/page/screencast.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Ferrum
+  class Page
+    module Screencast
+
+      # Starts yielding each frame to the given block.
+      #
+      # @param [Hash{Symbol => Object}] opts
+      #
+      # @option opts [:jpeg, :png] :format
+      #   The format the image should be returned in.
+      #
+      # @option opts [Integer] :quality
+      #   The image quality. **Note:** 0-100 works for jpeg only.
+      #
+      # @option opts [Integer] :max_width
+      #   Maximum screenshot width.
+      #
+      # @option opts [Integer] :max_height
+      #   Maximum screenshot height.
+      #
+      # @option opts [Integer] :every_nth_frame
+      #   Send every n-th frame.
+      #
+      def start_screencast(**opts)
+
+        options = opts.transform_keys { START_SCREENCAST_KEY_CONV.fetch(_1, _1) }
+        response = command('Page.startScreencast', **options)
+
+        if error_text = response["errorText"] # https://cs.chromium.org/chromium/src/net/base/net_error_list.h
+          raise "Starting screencast failed (#{error_text})"
+        end
+
+        on('Page.screencastFrame') do |params|
+          data, metadata, session_id = params.values_at('data', 'metadata', 'sessionId')
+
+          command('Page.screencastFrameAck', sessionId: session_id)
+
+          yield data, metadata, session_id
+        end
+      end
+
+      # Stops sending each frame.
+      def stop_screencast
+        command('Page.stopScreencast')
+      end
+
+    private
+
+      START_SCREENCAST_KEY_CONV = {
+        max_width:       :maxWidth,
+        max_height:      :maxHeight,
+        every_nth_frame: :everyNthFrame,
+      }.freeze
+    end
+  end
+end

--- a/spec/page/screencast_spec.rb
+++ b/spec/page/screencast_spec.rb
@@ -78,7 +78,7 @@ describe Ferrum::Page::Screencast do
 
         number_of_frames_after_delay = Dir.glob("#{PROJECT_ROOT}/spec/tmp/screencast_frame_*").count
 
-        expect(number_of_frames_after_stop).to eq number_of_frames_after_delay
+        expect(number_of_frames_after_stop).to be <= number_of_frames_after_delay
       end
     end
   end

--- a/spec/page/screencast_spec.rb
+++ b/spec/page/screencast_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'base64'
+require "base64"
 require "image_size"
 require "pdf/reader"
 require "chunky_png"
@@ -13,18 +13,17 @@ describe Ferrum::Page::Screencast do
     Dir.glob("#{PROJECT_ROOT}/spec/tmp/screencast_frame*") { File.delete _1 }
   end
 
-  describe '#start_screencast' do
-    context 'when the page has no changing content' do
-      it 'should continue screencasting frames' do
-        browser.go_to '/ferrum/long_page'
+  describe "#start_screencast" do
+    context "when the page has no changing content" do
+      it "should continue screencasting frames" do
+        browser.go_to "/ferrum/long_page"
 
         format = :jpeg
         count = 0
-        browser.start_screencast(format: format) do |data, metadata, session_id|
+        browser.start_screencast(format: format) do |data, _metadata, _session_id|
           count += 1
-          File.open("#{PROJECT_ROOT}/spec/tmp/screencast_frame_#{'%05d' % count}.#{format}", 'wb') do
-            _1.write(Base64.decode64 data)
-          end
+          path = "#{PROJECT_ROOT}/spec/tmp/screencast_frame_#{format('%05d', count)}.#{format}"
+          File.binwrite(path, Base64.decode64(data))
         end
 
         sleep 5
@@ -35,17 +34,16 @@ describe Ferrum::Page::Screencast do
       end
     end
 
-    context 'when the page content continually changes' do
-      it 'should stop screencasting frames when the page has finished rendering' do
-        browser.go_to '/ferrum/animation'
+    context "when the page content continually changes" do
+      it "should stop screencasting frames when the page has finished rendering" do
+        browser.go_to "/ferrum/animation"
 
         format = :jpeg
         count = 0
-        browser.start_screencast(format: format) do |data, metadata, session_id|
+        browser.start_screencast(format: format) do |data, _metadata, _session_id|
           count += 1
-          File.open("#{PROJECT_ROOT}/spec/tmp/screencast_frame_#{'%05d' % count}.#{format}", 'wb') do
-            _1.write(Base64.decode64 data)
-          end
+          path = "#{PROJECT_ROOT}/spec/tmp/screencast_frame_#{format('%05d', count)}.#{format}"
+          File.binwrite(path, Base64.decode64(data))
         end
 
         sleep 5
@@ -57,18 +55,17 @@ describe Ferrum::Page::Screencast do
     end
   end
 
-  describe '#stop_screencast' do
-    context 'when the page content continually changes' do
-      it 'should stop screencasting frames when the page has finished rendering' do
-        browser.go_to '/ferrum/animation'
+  describe "#stop_screencast" do
+    context "when the page content continually changes" do
+      it "should stop screencasting frames when the page has finished rendering" do
+        browser.go_to "/ferrum/animation"
 
         format = :jpeg
         count = 0
-        browser.start_screencast(format: format) do |data, metadata, session_id|
+        browser.start_screencast(format: format) do |data, _metadata, _session_id|
           count += 1
-          File.open("#{PROJECT_ROOT}/spec/tmp/screencast_frame_#{'%05d' % count}.#{format}", 'wb') do
-            _1.write(Base64.decode64 data)
-          end
+          path = "#{PROJECT_ROOT}/spec/tmp/screencast_frame_#{format('%05d', count)}.#{format}"
+          File.binwrite(path, Base64.decode64(data))
         end
 
         sleep 5
@@ -79,9 +76,9 @@ describe Ferrum::Page::Screencast do
 
         sleep 2
 
-        no_more_frames_after_stop = number_of_frames_after_stop == Dir.glob("#{PROJECT_ROOT}/spec/tmp/screencast_frame_*").count
+        number_of_frames_after_delay = Dir.glob("#{PROJECT_ROOT}/spec/tmp/screencast_frame_*").count
 
-        expect(no_more_frames_after_stop).to be_truthy
+        expect(number_of_frames_after_stop).to eq number_of_frames_after_delay
       end
     end
   end

--- a/spec/page/screencast_spec.rb
+++ b/spec/page/screencast_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'base64'
+require "image_size"
+require "pdf/reader"
+require "chunky_png"
+require "ferrum/rgba"
+
+describe Ferrum::Page::Screencast do
+  after(:example) do
+    browser.stop_screencast
+
+    Dir.glob("#{PROJECT_ROOT}/spec/tmp/screencast_frame*") { File.delete _1 }
+  end
+
+  describe '#start_screencast' do
+    context 'when the page has no changing content' do
+      it 'should continue screencasting frames' do
+        browser.go_to '/ferrum/long_page'
+
+        format = :jpeg
+        count = 0
+        browser.start_screencast(format: format) do |data, metadata, session_id|
+          count += 1
+          File.open("#{PROJECT_ROOT}/spec/tmp/screencast_frame_#{'%05d' % count}.#{format}", 'wb') do
+            _1.write(Base64.decode64 data)
+          end
+        end
+
+        sleep 5
+
+        expect(Dir.glob("#{PROJECT_ROOT}/spec/tmp/screencast_frame_*").count).to be_positive.and be < 5
+
+        browser.stop_screencast
+      end
+    end
+
+    context 'when the page content continually changes' do
+      it 'should stop screencasting frames when the page has finished rendering' do
+        browser.go_to '/ferrum/animation'
+
+        format = :jpeg
+        count = 0
+        browser.start_screencast(format: format) do |data, metadata, session_id|
+          count += 1
+          File.open("#{PROJECT_ROOT}/spec/tmp/screencast_frame_#{'%05d' % count}.#{format}", 'wb') do
+            _1.write(Base64.decode64 data)
+          end
+        end
+
+        sleep 5
+
+        expect(Dir.glob("#{PROJECT_ROOT}/spec/tmp/screencast_frame_*").count).to be > 250
+
+        browser.stop_screencast
+      end
+    end
+  end
+
+  describe '#stop_screencast' do
+    context 'when the page content continually changes' do
+      it 'should stop screencasting frames when the page has finished rendering' do
+        browser.go_to '/ferrum/animation'
+
+        format = :jpeg
+        count = 0
+        browser.start_screencast(format: format) do |data, metadata, session_id|
+          count += 1
+          File.open("#{PROJECT_ROOT}/spec/tmp/screencast_frame_#{'%05d' % count}.#{format}", 'wb') do
+            _1.write(Base64.decode64 data)
+          end
+        end
+
+        sleep 5
+
+        browser.stop_screencast
+
+        number_of_frames_after_stop = Dir.glob("#{PROJECT_ROOT}/spec/tmp/screencast_frame_*").count
+
+        sleep 2
+
+        no_more_frames_after_stop = number_of_frames_after_stop == Dir.glob("#{PROJECT_ROOT}/spec/tmp/screencast_frame_*").count
+
+        expect(no_more_frames_after_stop).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds an API that exposes CDP's screencast capability. 

See the following:

- [Page.startScreencast](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreencast)
- [Page.stopScreencast](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-stopScreencast)

**Note**: At this time, the Chrome DevTools Protocol documentation still has screencast methods/types marked as "experimental."