### PR TITLE
Add Ferrum::Brower::Base.version method

### DIFF
--- a/lib/ferrum/browser/options/base.rb
+++ b/lib/ferrum/browser/options/base.rb
@@ -15,7 +15,7 @@ module Ferrum
 
         # @return [String, nil]
         def self.version
-          out, _ = Open3.capture2(detect_path, "--version")
+          out, = Open3.capture2(detect_path, "--version")
           out.strip
         rescue Errno::ENOENT
           nil

--- a/lib/ferrum/browser/options/base.rb
+++ b/lib/ferrum/browser/options/base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "singleton"
+require "open3"
 
 module Ferrum
   class Browser
@@ -10,6 +11,14 @@ module Ferrum
 
         def self.options
           instance
+        end
+
+        # @return [String, nil]
+        def self.version
+          out, _ = Open3.capture2(detect_path, "--version")
+          out.strip
+        rescue Errno::ENOENT
+          nil
         end
 
         def to_h

--- a/lib/ferrum/browser/options/base.rb
+++ b/lib/ferrum/browser/options/base.rb
@@ -15,7 +15,7 @@ module Ferrum
 
         # @return [String, nil]
         def self.version
-          out, = Open3.capture2(detect_path, "--version")
+          out, = Open3.capture2(instance.detect_path, "--version")
           out.strip
         rescue Errno::ENOENT
           nil

--- a/spec/browser/options/chrome_spec.rb
+++ b/spec/browser/options/chrome_spec.rb
@@ -28,7 +28,7 @@ describe Ferrum::Browser::Options::Chrome do
 
   describe ".version" do
     it "returns an executable version" do
-      expect(described_class.version).to match(/Chromium \d/)
+      expect(described_class.version).to match(/(Chromium|Chrome) \d/)
     end
   end
 end

--- a/spec/browser/options/chrome_spec.rb
+++ b/spec/browser/options/chrome_spec.rb
@@ -25,4 +25,10 @@ describe Ferrum::Browser::Options::Chrome do
       expect(defaults.merge_default({}, options)).not_to include("use-angle" => "metal")
     end
   end
+
+  describe ".version" do
+    it "returns an executable version" do
+      expect(described_class.version).to match(/Chromium \d/)
+    end
+  end
 end


### PR DESCRIPTION
It returns the actual executable's version such as `Chromium 129.0.6668.89 built on Ubuntu 24.04.1 LTS`