### PR TITLE
screencast updated

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -22,6 +22,7 @@ module Ferrum
                 body doctype content=
                 headers cookies network downloads
                 mouse keyboard
+                start_screencast stop_screencast
                 screenshot pdf mhtml viewport_size device_pixel_ratio
                 frames frame_by main_frame
                 evaluate evaluate_on evaluate_async execute evaluate_func

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -454,7 +454,7 @@ module Ferrum
         end
       end
 
-      on(:screencastFrame) do |params, index, total|
+      on(:screencastFrame) do |params, _index, _total|
         @screencaster.add_frame(params)
         warn "DEBUG: frame added in page.rb"
       end

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -453,6 +453,7 @@ module Ferrum
 
       on(:screencastFrame) do |params, index, total|
         @screencaster.add_frame(params)
+        warn "DEBUG: frame added in page.rb"
       end
     end
 

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -72,6 +72,9 @@ module Ferrum
     # @return [Downloads]
     attr_reader :downloads
 
+    # Control Screencasting
+    #
+    # @return [nil]
     attr_reader :screencaster
 
     def initialize(client, context_id:, target_id:, proxy: nil)

--- a/lib/ferrum/page/screencast.rb
+++ b/lib/ferrum/page/screencast.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require "ferrum/screencaster"
+
+
+module Ferrum
+  class Page
+    module Screencast
+      attr_reader :screencaster
+
+      def start_screencast #(options)
+        @screencaster.await.start_screencast
+      end
+
+      def stop_screencast
+        @screencaster.await.stop_screencast
+      end
+    end
+  end
+end

--- a/lib/ferrum/page/screencast.rb
+++ b/lib/ferrum/page/screencast.rb
@@ -8,11 +8,11 @@ module Ferrum
       attr_reader :screencaster
 
       def start_screencast #(options)
-        @screencaster.await.start_screencast
+        @screencaster.start_screencast
       end
 
       def stop_screencast
-        @screencaster.await.stop_screencast
+        @screencaster.stop_screencast
       end
     end
   end

--- a/lib/ferrum/page/screencast.rb
+++ b/lib/ferrum/page/screencast.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "ferrum/screencaster"
 
 module Ferrum
@@ -6,7 +7,7 @@ module Ferrum
     module Screencast
       attr_reader :screencaster
 
-      def start_screencast #(options)
+      def start_screencast
         @screencaster.start_screencast
       end
 

--- a/lib/ferrum/page/screencast.rb
+++ b/lib/ferrum/page/screencast.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "ferrum/screencaster"
 
-
 module Ferrum
   class Page
     module Screencast

--- a/lib/ferrum/screencaster.rb
+++ b/lib/ferrum/screencaster.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'stringio'
+#TODO these ^ need to be added to gemfile
+require 'concurrent-ruby'
+
+module Ferrum
+  class Screencaster
+ #   attr_reader :message, :default_prompt
+      include Concurrent::Async
+
+      def initialize(page)
+        @page = page #might be wrong
+        @stdin = StringIO.new
+        @stdout = StringIO.new
+        @stderr = StringIO.new
+        @wait_thr = nil
+      end
+
+      def add_frame(params)
+        @page.command("Page.screencastFrameAck")
+        img = params["data"]
+        img_decoded = Base64.decode64(img)
+        @stdin.write(img_decoded)
+      end
+
+      def start_screencast #(options)
+        cmd = "ffmpeg -y -f rawvideo -pix_fmt rgb24 -s 640x480 -r 30 -i - -vcodec mp4v -c:v libx264 -preset slow -crf 22 output_video.mp4"
+        @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(cmd)
+        @page.command("Page.startScreencast") #, **options)
+      end
+
+      def stop_screencast
+        @page.command("Page.stopScreencast")
+        @stdin.close
+      end
+  end
+end

--- a/lib/ferrum/screencaster.rb
+++ b/lib/ferrum/screencaster.rb
@@ -19,21 +19,27 @@ module Ferrum
       end
 
       def add_frame(params)
-        @page.command("Page.screencastFrameAck")
+        warn 'frame'
+        @page.command("Page.screencastFrameAck", sessionId: params["sessionId"])
         img = params["data"]
         img_decoded = Base64.decode64(img)
         @stdin.write(img_decoded)
+
       end
 
       def start_screencast #(options)
-        cmd = "ffmpeg -y -f rawvideo -pix_fmt rgb24 -s 640x480 -r 30 -i - -vcodec mp4v -c:v libx264 -preset slow -crf 22 output_video.mp4"
+        cmd = "ffmpeg -y -f image2pipe -i - -c:v libx264 -preset slow -crf 22 -r 1 -an -f mp4 -movflags +faststart output_video2.mp4"
         @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(cmd)
-        @page.command("Page.startScreencast") #, **options)
+        @page.command("Page.startScreencast", format: "jpeg") #, **options)
       end
 
       def stop_screencast
+        warn 'stopped'
         @page.command("Page.stopScreencast")
         @stdin.close
+        @stdout.close
+        @stderr.close
+        @wait_thr.join
       end
   end
 end

--- a/lib/ferrum/screencaster.rb
+++ b/lib/ferrum/screencaster.rb
@@ -2,25 +2,25 @@
 
 module Ferrum
   class Screencaster
-      def initialize(page)
-        @page = page
-      end
+    def initialize(page)
+      @page = page
+    end
 
-      def add_frame(params)
-        warn 'frame'
-        @page.command("Page.screencastFrameAck", sessionId: params["sessionId"])
+    def add_frame(params)
+      warn "frame"
+      @page.command("Page.screencastFrameAck", sessionId: params["sessionId"])
 
-        ts = (Time.now.to_f * 1000).to_i
-        File.binwrite("img_#{ts}.jpeg", Base64.decode64(params["data"]))
-      end
+      ts = (Time.now.to_f * 1000).to_i
+      File.binwrite("img_#{ts}.jpeg", Base64.decode64(params["data"]))
+    end
 
-      def start_screencast
-        @page.command("Page.startScreencast", format: "jpeg")
-      end
+    def start_screencast
+      @page.command("Page.startScreencast", format: "jpeg")
+    end
 
-      def stop_screencast
-        warn 'stopped'
-        @page.command("Page.stopScreencast")
-      end
+    def stop_screencast
+      warn "stopped"
+      @page.command("Page.stopScreencast")
+    end
   end
 end

--- a/lib/ferrum/screencaster.rb
+++ b/lib/ferrum/screencaster.rb
@@ -1,45 +1,26 @@
 # frozen_string_literal: true
 
-require 'open3'
-require 'stringio'
-#TODO these ^ need to be added to gemfile
-require 'concurrent-ruby'
-
 module Ferrum
   class Screencaster
- #   attr_reader :message, :default_prompt
-      include Concurrent::Async
-
       def initialize(page)
-        @page = page #might be wrong
-        @stdin = StringIO.new
-        @stdout = StringIO.new
-        @stderr = StringIO.new
-        @wait_thr = nil
+        @page = page
       end
 
       def add_frame(params)
         warn 'frame'
         @page.command("Page.screencastFrameAck", sessionId: params["sessionId"])
-        img = params["data"]
-        img_decoded = Base64.decode64(img)
-        @stdin.write(img_decoded)
 
+        ts = (Time.now.to_f * 1000).to_i
+        File.binwrite("img_#{ts}.jpeg", Base64.decode64(params["data"]))
       end
 
-      def start_screencast #(options)
-        cmd = "ffmpeg -y -f image2pipe -i - -c:v libx264 -preset slow -crf 22 -r 1 -an -f mp4 -movflags +faststart output_video2.mp4"
-        @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(cmd)
-        @page.command("Page.startScreencast", format: "jpeg") #, **options)
+      def start_screencast
+        @page.command("Page.startScreencast", format: "jpeg")
       end
 
       def stop_screencast
         warn 'stopped'
         @page.command("Page.stopScreencast")
-        @stdin.close
-        @stdout.close
-        @stderr.close
-        @wait_thr.join
       end
   end
 end

--- a/lib/ferrum/screencaster.rb
+++ b/lib/ferrum/screencaster.rb
@@ -1,24 +1,45 @@
 # frozen_string_literal: true
+require 'fileutils'
 
+# Combine the resulting frames together into a video with:
+# ffmpeg -y -framerate 30 -i 'frame-%d.jpeg' -c:v libx264 -r 30 -pix_fmt yuv420p try2.mp4
+#
 module Ferrum
   class Screencaster
     def initialize(page)
       @page = page
+      @frame_number = 0
+      @threads = []
+      @base_dir = ""
     end
 
     def add_frame(params)
       warn "frame"
+
       @page.command("Page.screencastFrameAck", sessionId: params["sessionId"])
 
-      ts = (Time.now.to_f * 1000).to_i
-      File.binwrite("img_#{ts}.jpeg", Base64.decode64(params["data"]))
+      t = Thread.new { File.binwrite("#{recordings_dir}/frame-#{@frame_number}.jpeg", Base64.decode64(params["data"])) }
+      @frame_number += 1
+      @threads << t
+      true
     end
 
-    def start_screencast
+    def recordings_dir
+      return @recordings_dir if defined? @recordings_dir
+
+      session_id = @page.client.session_id
+      @recordings_dir = FileUtils.mkdir_p("#{@base_dir}/screencast_recordings/#{session_id}/").first
+      @recordings_dir
+    end
+
+    def start_screencast(base_dir = "")
+      @base_dir = base_dir
       @page.command("Page.startScreencast", format: "jpeg")
     end
 
     def stop_screencast
+      warn "joining threads"
+      @threads.each(&:join)
       warn "stopped"
       @page.command("Page.stopScreencast")
     end


### PR DESCRIPTION
- **initial feature skeleton, lacks async capability and doesn't work :'(**
- **tweaks, methods can now generate very tiny mp4s**
- **Only save images from screencast: Images can be combined later**
- **Rubocop formatting**
- **Background writing frames to disk; put them in a dir; start from 0 to more easily use ffmpeg to create videos from them**
