### PR TITLE
Feat: Add Screencasting of the browser, save images. v0.15 compatible with Cuprite

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -22,6 +22,7 @@ module Ferrum
                 body doctype content=
                 headers cookies network downloads
                 mouse keyboard
+                start_screencast stop_screencast
                 screenshot pdf mhtml viewport_size device_pixel_ratio
                 frames frame_by main_frame
                 evaluate evaluate_on evaluate_async execute evaluate_func

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -440,7 +440,6 @@ module Ferrum
 
       on(:screencastFrame) do |params, _index, _total|
         @screencaster.add_frame(params)
-        warn "DEBUG: frame added in page.rb"
       end
     end
 

--- a/lib/ferrum/page/screencast.rb
+++ b/lib/ferrum/page/screencast.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "ferrum/screencaster"
+
+module Ferrum
+  class Page
+    module Screencast
+      attr_reader :screencaster
+
+      def start_screencast
+        @screencaster.start_screencast
+      end
+
+      def stop_screencast
+        @screencaster.stop_screencast
+      end
+    end
+  end
+end

--- a/lib/ferrum/page/screencast.rb
+++ b/lib/ferrum/page/screencast.rb
@@ -7,8 +7,8 @@ module Ferrum
     module Screencast
       attr_reader :screencaster
 
-      def start_screencast
-        @screencaster.start_screencast
+      def start_screencast(...)
+        @screencaster.start_screencast(...)
       end
 
       def stop_screencast

--- a/lib/ferrum/screencaster.rb
+++ b/lib/ferrum/screencaster.rb
@@ -10,28 +10,23 @@ module Ferrum
       @page = page
       @frame_number = 0
       @threads = []
-      @base_dir = ""
+      @save_path
     end
 
     def add_frame(params)
       @page.command("Page.screencastFrameAck", sessionId: params["sessionId"])
 
-      t = Thread.new { File.binwrite("#{recordings_dir}/frame-#{@frame_number}.jpeg", Base64.decode64(params["data"])) }
+      t = Thread.new { File.binwrite("#{@save_path}/frame-#{@frame_number}.jpeg", Base64.decode64(params["data"])) }
       @frame_number += 1
       @threads << t
       true
     end
 
-    def recordings_dir
-      return @recordings_dir if defined? @recordings_dir
 
-      timestamp = (Time.now.to_f * 1000).to_i
-      @recordings_dir = FileUtils.mkdir_p("#{@base_dir}/screencast_recordings/#{timestamp}/").first
-      @recordings_dir
-    end
-
-    def start_screencast(base_dir = "")
-      @base_dir = base_dir
+		# save_path: Directory where individual frames from the screencast will be saved
+    def start_screencast(save_path)
+      @save_path = save_path
+      raise "Save path for screen recording does not exist" unless Dir.exist?(@save_path)
       @page.command("Page.startScreencast", format: "jpeg")
     end
 

--- a/lib/ferrum/screencaster.rb
+++ b/lib/ferrum/screencaster.rb
@@ -14,8 +14,6 @@ module Ferrum
     end
 
     def add_frame(params)
-      warn "frame"
-
       @page.command("Page.screencastFrameAck", sessionId: params["sessionId"])
 
       t = Thread.new { File.binwrite("#{recordings_dir}/frame-#{@frame_number}.jpeg", Base64.decode64(params["data"])) }
@@ -38,9 +36,7 @@ module Ferrum
     end
 
     def stop_screencast
-      warn "joining threads"
       @threads.each(&:join)
-      warn "stopped"
       @page.command("Page.stopScreencast")
     end
   end

--- a/lib/ferrum/screencaster.rb
+++ b/lib/ferrum/screencaster.rb
@@ -27,8 +27,8 @@ module Ferrum
     def recordings_dir
       return @recordings_dir if defined? @recordings_dir
 
-      session_id = @page.client.session_id
-      @recordings_dir = FileUtils.mkdir_p("#{@base_dir}/screencast_recordings/#{session_id}/").first
+      timestamp = (Time.now.to_f * 1000).to_i
+      @recordings_dir = FileUtils.mkdir_p("#{@base_dir}/screencast_recordings/#{timestamp}/").first
       @recordings_dir
     end
 

--- a/lib/ferrum/screencaster.rb
+++ b/lib/ferrum/screencaster.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'fileutils'
+
+# Combine the resulting frames together into a video with:
+# ffmpeg -y -framerate 30 -i 'frame-%d.jpeg' -c:v libx264 -r 30 -pix_fmt yuv420p try2.mp4
+#
+module Ferrum
+  class Screencaster
+    def initialize(page)
+      @page = page
+      @frame_number = 0
+      @threads = []
+      @base_dir = ""
+    end
+
+    def add_frame(params)
+      warn "frame"
+
+      @page.command("Page.screencastFrameAck", sessionId: params["sessionId"])
+
+      t = Thread.new { File.binwrite("#{recordings_dir}/frame-#{@frame_number}.jpeg", Base64.decode64(params["data"])) }
+      @frame_number += 1
+      @threads << t
+      true
+    end
+
+    def recordings_dir
+      return @recordings_dir if defined? @recordings_dir
+
+      session_id = @page.client.session_id
+      @recordings_dir = FileUtils.mkdir_p("#{@base_dir}/screencast_recordings/#{session_id}/").first
+      @recordings_dir
+    end
+
+    def start_screencast(base_dir = "")
+      @base_dir = base_dir
+      @page.command("Page.startScreencast", format: "jpeg")
+    end
+
+    def stop_screencast
+      warn "joining threads"
+      @threads.each(&:join)
+      warn "stopped"
+      @page.command("Page.stopScreencast")
+    end
+  end
+end

--- a/lib/ferrum/screencaster.rb
+++ b/lib/ferrum/screencaster.rb
@@ -2,7 +2,7 @@
 require 'fileutils'
 
 # Combine the resulting frames together into a video with:
-# ffmpeg -y -framerate 30 -i 'frame-%d.jpeg' -c:v libx264 -r 30 -pix_fmt yuv420p try2.mp4
+# ffmpeg -y -framerate 30 -i 'frame-%d.jpeg' -c:v libx264 -r 30 -pix_fmt yuv420p output.mp4
 #
 module Ferrum
   class Screencaster


### PR DESCRIPTION
Work in progress.

To use this:
```
page.driver.browser.page.start_screencast(save_dir)
page.driver.browser.page.stop_screencast
```

This only saves images, it's not true video/screencasting but that is actually what Chrome provides.
This could become a 'real' screencast by streaming the images received from Chrome to something that combines them into a video (`ffmpeg`), but that would require much more complication in this Gem - and can just be done by a user later.

They should be very helpful for viewing and debugging tests.

Taken from this issue discussion: https://github.com/rubycdp/ferrum/issues/354

## Todo:

- [ ] Add tests
- [ ] Add configuration for screensharing: https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreencast