### PR TITLE
fix: wait_for_idle has issue with window.URL.createObjectURL

### DIFF
--- a/lib/ferrum/network/exchange.rb
+++ b/lib/ferrum/network/exchange.rb
@@ -83,7 +83,7 @@ module Ferrum
       # @return [Boolean]
       #
       def finished?
-        blocked? || response&.loaded? || !error.nil? || ping?
+        blocked? || response&.loaded? || !error.nil? || ping? || !!url&.start_with?("blob:")
       end
 
       #

--- a/spec/network/exchange_spec.rb
+++ b/spec/network/exchange_spec.rb
@@ -136,6 +136,21 @@ describe Ferrum::Network::Exchange do
       exchange.request = Ferrum::Network::Request.new({ "type" => "Ping" })
       expect(exchange.finished?).to be true
     end
+
+    it "returns true for blob requests" do
+      exchange = Ferrum::Network::Exchange.new(page, "1")
+      expect(exchange.finished?).to be false
+
+      exchange.request = Ferrum::Network::Request.new(
+        {
+          "type" => "Document",
+          "request" => {
+            "url" => "blob:null/75787aaf-a81f-4237-98d7-0d51fe6cfcba"
+          }
+        }
+      )
+      expect(exchange.finished?).to be true
+    end
   end
 
   describe "#redirect?" do


### PR DESCRIPTION
Resolves #496

I added a blob decision directly to `finished?` method.
Do we need a `blob?` method in the `Request` and `Exchange` classes?