### PR TITLE
Fix: Safe call body method (DOM) when page is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Correctly set mouse events buttons property [#509]
 - Prevent 'Hash#[]=': can't add a new key into hash during iteration [#513]
 - `Ferrum::Network::Exchange#finished?` and `Ferrum::Network#wait_for_idle` take into account that request can be a blob [#496]
+- Safe call _body_ method (DOM) when page is empty and no html [#522]
 
 ### Removed
 

--- a/lib/ferrum/frame/dom.rb
+++ b/lib/ferrum/frame/dom.rb
@@ -92,7 +92,7 @@ module Ferrum
       #   browser.body # => '<html itemscope="" itemtype="http://schema.org/WebPage" lang="ru"><head>...
       #
       def body
-        evaluate("document.documentElement.outerHTML")
+        evaluate("document.documentElement?.outerHTML") || ""
       end
 
       #

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -517,6 +517,6 @@ describe Ferrum::Network do
       %r{Request to http://.*/with_js failed \(net::ERR_INTERNET_DISCONNECTED\)}
     )
 
-    expect(page.at_css("body").text).to match("No internet")
+    expect(page.at_css("body").text).to match("")
   end
 end

--- a/spec/unit/browser_spec.rb
+++ b/spec/unit/browser_spec.rb
@@ -19,7 +19,7 @@ describe Ferrum::Browser do
     browser = Ferrum::Browser.new(logger: logger)
     browser.body
     file_log = File.read(file_path)
-    expect(file_log).to include("return document.documentElement.outerHTML")
+    expect(file_log).to include("return document.documentElement?.outerHTML")
     expect(file_log).to include("<html><head></head><body></body></html>")
   ensure
     FileUtils.rm_f(file_path)
@@ -32,7 +32,7 @@ describe Ferrum::Browser do
 
     browser.body
 
-    expect(logger.string).to include("return document.documentElement.outerHTML")
+    expect(logger.string).to include("return document.documentElement?.outerHTML")
     expect(logger.string).to include("<html><head></head><body></body></html>")
   ensure
     browser.quit


### PR DESCRIPTION
In some cases method _body_ (DOM) can raise an exception. It happens when page is empty and there is no _html_
e.g. 
```
=> browser = ::Ferrum::Browser.new
=> browser.goto('https://somesitewithemptypage.com') # <—— here we receive empty page
=> browser.body 
=> 
Ferrum::JavaScriptError: TypeError: Cannot read properties of null (reading 'outerHTML') |  
```
This PR will add safe call method _body_ for reducing errors 