### PR TITLE
feat: Add `Frame#frame_element` method

### DIFF
--- a/lib/ferrum/frame/dom.rb
+++ b/lib/ferrum/frame/dom.rb
@@ -96,6 +96,22 @@ module Ferrum
       end
 
       #
+      # Returns the element in which the window is embedded.
+      #
+      # @return [Node, nil]
+      #   The element in which the window is embedded.
+      #
+      # @example
+      #   browser.go_to("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe")
+      #   frame = browser.frames.last
+      #   frame.frame_element # => [Node]
+      #   frame.parent.parent.parent.frame_element # => nil
+      #
+      def frame_element
+        evaluate("window.frameElement")
+      end
+
+      #
       # Finds nodes by using a XPath selector.
       #
       # @param [String] selector


### PR DESCRIPTION
⚠️ ~~**Includes commit from #523** - please review/merge that PR first.~~

Faciliates easier retrieval of the `iframe` element that embeds the `window` (represented as a `Frame` object by Ferrum).

This is extracted from my Cuprite PR here: https://github.com/rubycdp/cuprite/pull/291 _(that PR doesn't currently depend on this PR being merged, but the Cuprite PR could easily be adapted to call the newly-added Ferum `Frame#node` method)_.