### PR TITLE
Enable mobile emulation

### DIFF
--- a/docs/2-customization.md
+++ b/docs/2-customization.md
@@ -56,6 +56,15 @@ Ferrum::Browser.new(options)
     * `:save_path` (String) - Path to save attachments with [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header.
     * `:env` (Hash) - Environment variables you'd like to pass through to the process
 
+You can emulate specific devices at the time you register a driver:
+
+```ruby
+require "capybara/cuprite/devices"
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(app, Capybara::Cuprite::Devices::IPHONE_14)
+end
+```
+
 ## Examples
 
 ```ruby

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -133,6 +133,8 @@ module Ferrum
     # @option options [Hash] :env
     #   Environment variables you'd like to pass through to the process.
     #
+    # @option options [Boolean] :mobile
+    #   Specify whether to enable mobile emulation and touch UI.
     def initialize(options = nil)
       @options = Options.new(options)
       @client = @process = @contexts = nil

--- a/lib/ferrum/browser/options.rb
+++ b/lib/ferrum/browser/options.rb
@@ -15,7 +15,7 @@ module Ferrum
                   :js_errors, :base_url, :slowmo, :pending_connection_errors,
                   :url, :ws_url, :env, :process_timeout, :browser_name, :browser_path,
                   :save_path, :proxy, :port, :host, :headless, :incognito, :dockerize, :browser_options,
-                  :ignore_default_browser_options, :xvfb, :flatten
+                  :ignore_default_browser_options, :xvfb, :flatten, :mobile
       attr_accessor :timeout, :default_user_agent
 
       def initialize(options = nil)
@@ -33,6 +33,7 @@ module Ferrum
         @pending_connection_errors = @options.fetch(:pending_connection_errors, true)
         @process_timeout = @options.fetch(:process_timeout, PROCESS_TIMEOUT)
         @slowmo = @options[:slowmo].to_f
+        @mobile = @options.fetch(:mobile, false)
 
         @env = @options[:env]
         @xvfb = @options[:xvfb]

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -94,8 +94,12 @@ module Ferrum
           process_options[:out] = process_options[:err] = write_io
 
           if @command.xvfb?
-            @xvfb = Xvfb.start(@command.options)
-            ObjectSpace.define_finalizer(self, self.class.process_killer(@xvfb.pid))
+            if @command.options.xvfb.respond_to?(:start)
+              @xvfb = @command.options.xvfb.start(@command.options)
+            else
+              @xvfb = Xvfb.start(@command.options)
+              ObjectSpace.define_finalizer(self, self.class.process_killer(@xvfb.pid))
+            end
           end
 
           env = Hash(@xvfb&.to_env).merge(@env)

--- a/lib/ferrum/client.rb
+++ b/lib/ferrum/client.rb
@@ -66,6 +66,7 @@ module Ferrum
 
     attr_reader :ws_url, :options, :subscriber
     attr_accessor :on_synchronous_message
+
     def initialize(ws_url, options)
       @command_id = 0
       @ws_url = ws_url
@@ -97,9 +98,7 @@ module Ferrum
         raise TimeoutError unless data
 
         error, response = data.values_at("error", "result")
-        if on_synchronous_message
-          on_synchronous_message.call(message:, error:, response:)
-        end
+        on_synchronous_message&.call(message:, error:, response:)
         raise_browser_error(error) if error
         response
       end

--- a/lib/ferrum/client.rb
+++ b/lib/ferrum/client.rb
@@ -65,7 +65,7 @@ module Ferrum
     delegate %i[timeout timeout=] => :options
 
     attr_reader :ws_url, :options, :subscriber
-    attr_accessor :on_syncronous_message
+    attr_accessor :on_synchronous_message
     def initialize(ws_url, options)
       @command_id = 0
       @ws_url = ws_url
@@ -97,8 +97,8 @@ module Ferrum
         raise TimeoutError unless data
 
         error, response = data.values_at("error", "result")
-        if on_syncronous_message
-          on_syncronous_message.call(message:, error:, response:)
+        if on_synchronous_message
+          on_synchronous_message.call(message:, error:, response:)
         end
         raise_browser_error(error) if error
         response

--- a/lib/ferrum/client.rb
+++ b/lib/ferrum/client.rb
@@ -65,7 +65,7 @@ module Ferrum
     delegate %i[timeout timeout=] => :options
 
     attr_reader :ws_url, :options, :subscriber
-
+    attr_accessor :on_syncronous_message
     def initialize(ws_url, options)
       @command_id = 0
       @ws_url = ws_url
@@ -97,6 +97,9 @@ module Ferrum
         raise TimeoutError unless data
 
         error, response = data.values_at("error", "result")
+        if on_syncronous_message
+          on_syncronous_message.call(message:, error:, response:)
+        end
         raise_browser_error(error) if error
         response
       end

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -158,9 +158,22 @@ module Ferrum
         deviceScaleFactor: scale_factor,
         mobile: mobile
       )
+
+      options = if mobile
+                  {
+                    enabled: true,
+                    maxTouchPoints: 1
+                  }
+                else
+                  {
+                    enabled: false
+                  }
+                end
+
+      command("Emulation.setTouchEmulationEnabled", **options)
     end
 
-    def resize(width: nil, height: nil, fullscreen: false)
+    def resize(width: nil, height: nil, fullscreen: false, mobile: false)
       if fullscreen
         width, height = document_size
         self.window_bounds = { window_state: "fullscreen" }
@@ -169,7 +182,7 @@ module Ferrum
         self.window_bounds = { width: width, height: height }
       end
 
-      set_viewport(width: width, height: height)
+      set_viewport(width: width, height: height, mobile: mobile)
     end
 
     #

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -137,7 +137,11 @@ module Ferrum
     end
 
     #
-    # Overrides device screen dimensions and emulates viewport according to parameters
+    # Overrides device screen dimensions and emulates viewport according to parameters.
+    #
+    # Note that passing mobile: true will cause set_viewport to ignore the passed
+    # height and width values, and instead use 390 x 844, which is the viewport size
+    # of an iPhone 14.
     #
     # Read more [here](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride).
     #
@@ -150,27 +154,36 @@ module Ferrum
     # @param [Boolean] mobile whether to emulate mobile device
     #
     def set_viewport(width:, height:, scale_factor: 0, mobile: false)
-      command(
-        "Emulation.setDeviceMetricsOverride",
-        slowmoable: true,
-        width: width,
-        height: height,
-        deviceScaleFactor: scale_factor,
-        mobile: mobile
-      )
+      if mobile
+        command(
+          "Emulation.setTouchEmulationEnabled",
+          enabled: true,
+          maxTouchPoints: 1
+        )
 
-      options = if mobile
-                  {
-                    enabled: true,
-                    maxTouchPoints: 1
-                  }
-                else
-                  {
-                    enabled: false
-                  }
-                end
+        command(
+          "Emulation.setDeviceMetricsOverride",
+          deviceScaleFactor: 3.0,
+          height: 844,
+          mobile: true,
+          slowmoable: true,
+          width: 390
+        )
+      else
+        command(
+          "Emulation.setTouchEmulationEnabled",
+          enabled: false
+        )
 
-      command("Emulation.setTouchEmulationEnabled", **options)
+        command(
+          "Emulation.setDeviceMetricsOverride",
+          deviceScaleFactor: scale_factor,
+          height: height,
+          mobile: false,
+          slowmoable: true,
+          width: width
+        )
+      end
     end
 
     def resize(width: nil, height: nil, fullscreen: false, mobile: false)

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -139,10 +139,6 @@ module Ferrum
     #
     # Overrides device screen dimensions and emulates viewport according to parameters.
     #
-    # Note that passing mobile: true will cause set_viewport to ignore the passed
-    # height and width values, and instead use 390 x 844, which is the viewport size
-    # of an iPhone 14.
-    #
     # Read more [here](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride).
     #
     # @param [Integer] width width value in pixels. 0 disables the override
@@ -160,30 +156,21 @@ module Ferrum
           enabled: true,
           maxTouchPoints: 1
         )
-
-        command(
-          "Emulation.setDeviceMetricsOverride",
-          deviceScaleFactor: 3.0,
-          height: 844,
-          mobile: true,
-          slowmoable: true,
-          width: 390
-        )
       else
         command(
           "Emulation.setTouchEmulationEnabled",
           enabled: false
         )
-
-        command(
-          "Emulation.setDeviceMetricsOverride",
-          deviceScaleFactor: scale_factor,
-          height: height,
-          mobile: false,
-          slowmoable: true,
-          width: width
-        )
       end
+
+      command(
+        "Emulation.setDeviceMetricsOverride",
+        deviceScaleFactor: scale_factor,
+        height: height,
+        mobile: mobile,
+        slowmoable: true,
+        width: width
+      )
     end
 
     def resize(width: nil, height: nil, fullscreen: false, mobile: false)

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -260,13 +260,13 @@ describe Ferrum::Page do
 
     context "given a zero height" do
       it "does not change the height" do
-        expect { page.resize(width: 2000, height: 0) }.not_to change { body_size[:height] }
+        expect { page.resize(width: 2000, height: 0) }.not_to(change { body_size[:height] })
       end
     end
 
     context "given a zero width" do
       it "does not change the width" do
-        expect { page.resize(width: 0, height: 1000) }.not_to change { body_size[:width] }
+        expect { page.resize(width: 0, height: 1000) }.not_to(change { body_size[:width] })
       end
     end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -277,13 +277,6 @@ describe Ferrum::Page do
           page.reload
         end.to change { is_mobile? }.to(true)
       end
-
-      it "resizes to the size of an iPhone 14 viewport, taking into account scale factor" do
-        expect do
-          page.resize(width: 0, height: 0, mobile: true)
-          page.reload
-        end.to change { body_size }.to(width: 980, height: 2120)
-      end
     end
   end
 end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -277,6 +277,13 @@ describe Ferrum::Page do
           page.reload
         end.to change { is_mobile? }.to(true)
       end
+
+      it "resizes to the size of an iPhone 14 viewport, taking into account scale factor" do
+        expect do
+          page.resize(width: 0, height: 0, mobile: true)
+          page.reload
+        end.to change { body_size }.to(width: 980, height: 2120)
+      end
     end
   end
 end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -235,4 +235,48 @@ describe Ferrum::Page do
       wait_for { message_b }.to eq("goodbye")
     end
   end
+
+  describe "#resize" do
+    def body_size
+      {
+        height: page.evaluate("document.body.clientHeight"),
+        width: page.evaluate("document.body.clientWidth")
+      }
+    end
+
+    def is_mobile?
+      page.evaluate("'ontouchstart' in window || navigator.maxTouchPoints > 0")
+    end
+
+    before do
+      page.go_to("/")
+    end
+
+    context "given a different size" do
+      it "resizes the page" do
+        expect { page.resize(width: 2000, height: 1000) }.to change { body_size }.to(width: 2000, height: 1000)
+      end
+    end
+
+    context "given a zero height" do
+      it "does not change the height" do
+        expect { page.resize(width: 2000, height: 0) }.not_to change { body_size[:height] }
+      end
+    end
+
+    context "given a zero width" do
+      it "does not change the width" do
+        expect { page.resize(width: 0, height: 1000) }.not_to change { body_size[:width] }
+      end
+    end
+
+    context "when mobile is true" do
+      it "enables mobile emulation in the browser" do
+        expect do
+          page.resize(width: 0, height: 0, mobile: true)
+          page.reload
+        end.to change { is_mobile? }.to(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
There is a request on Cuprite to support mobile emulation: https://github.com/rubycdp/cuprite/issues/216

A prerequisite for this is for Ferrum to support `mobile: true` in `Page#resize`.  This PR adds that support.

Note that passing `mobile: true` also sets the screen resolution to that of an iPhone 14; see [this comment](https://github.com/rubycdp/ferrum/pull/527#pullrequestreview-2708886758).  Perhaps there's a nicer way of doing this?

Merging this should let us close #94.