### PR TITLE
Fix for nextwork_spec.rb:512 "#offline_mode"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp
 .idea
 .ruby-version
 .yardoc
+.tool-versions

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -517,6 +517,6 @@ describe Ferrum::Network do
       %r{Request to http://.*/with_js failed \(net::ERR_INTERNET_DISCONNECTED\)}
     )
 
-    expect(page.at_css("body").text).to match("No internet")
+    expect(page.at_css("body").text).to match("No Internet")
   end
 end

--- a/spec/network_spec.rb
+++ b/spec/network_spec.rb
@@ -517,6 +517,6 @@ describe Ferrum::Network do
       %r{Request to http://.*/with_js failed \(net::ERR_INTERNET_DISCONNECTED\)}
     )
 
-    expect(page.at_css("body").text).to match("No Internet")
+    expect(page.at_css("body").text.downcase).to match("no internet")
   end
 end


### PR DESCRIPTION
For me the message contains "No Internet", but the test expects "No internet".

The PR downcases the text before matching.