### PR TITLE
Rescue error on disposeBrowserContext when context is missing

### DIFF
--- a/lib/ferrum/client.rb
+++ b/lib/ferrum/client.rb
@@ -165,7 +165,7 @@ module Ferrum
            "Inspected target navigated or closed"
         raise NodeNotFoundError, error
       # Context is lost, page is reloading
-      when "Cannot find context with specified id"
+      when "Cannot find context with specified id", /Failed to find context with id/
         raise NoExecutionContextError, error
       when "No target with given id found"
         raise NoSuchPageError


### PR DESCRIPTION
See my comments on Issue #540.