### PR TITLE
Puma 7.0 requires its config to be `clamp`ed before reading any values.

### DIFF
--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -104,6 +104,7 @@ module Ferrum
     def run
       options = { Host: host, Port: port, Threads: "0:4", workers: 0, daemon: false }
       config = Rack::Handler::Puma.config(middleware, options)
+      config.clamp
       log_writer = config.options[:Silent] ? ::Puma::LogWriter.strings : ::Puma::LogWriter.stdio
       config.options[:log_writer] = log_writer
 


### PR DESCRIPTION
Hello! Thanks very much for ferrum. I'm getting ready to do some dev on it, and after cloning, immediately ran into `rake` erroring out with:
```
  Error: #<Thread:0x00007906eabf2e98 /home/micah/work/ferrum/spec/support/server.rb:87 run> terminated with exception (report_on_exception is true):
     /home/micah/.rvm/gems/ruby-3.3.4@ferrum/gems/puma-7.0.4/lib/puma/configuration.rb:202:in `options': ensure clamp is called before accessing options (Puma::Configuration::NotClampedError)
        from /home/micah/work/ferrum/spec/support/server.rb:107:in `run'
        from /home/micah/work/ferrum/spec/support/server.rb:87:in `block in boot!'
     /home/micah/.rvm/rubies/ruby-3.3.4/bin/ruby -w -I/home/micah/.rvm/gems/ruby-3.3.4@ferrum/gems/rspec-core-3.13.5/lib:/home/micah/.rvm/gems/ruby-3.3.4@ferrum/gems/rspec-support-3.13.6/lib 
     /home/micah/.rvm/gems/ruby-3.3.4@ferrum/gems/rspec-core-3.13.5/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed

     /home/micah/.rvm/rubies/ruby-3.3.4/bin/ruby -w -I/home/micah/.rvm/gems/ruby-3.3.4@ferrum/gems/rspec-core-3.13.5/lib:/home/micah/.rvm/gems/ruby-3.3.4@ferrum/gems/rspec-support-3.13.6/lib 
     /home/micah/.rvm/gems/ruby-3.3.4@ferrum/gems/rspec-core-3.13.5/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
```

Looking at https://github.com/puma/puma/blob/master/History.md#700--2025-09-03 it looks like Puma 7 requires the config to have `clamp` called on it now.