### PR TITLE
Disable Chrome code sign clones

### DIFF
--- a/lib/ferrum/browser/options/chrome.rb
+++ b/lib/ferrum/browser/options/chrome.rb
@@ -20,7 +20,7 @@ module Ferrum
           "disable-extensions" => nil,
           "disable-component-extensions-with-background-pages" => nil,
           "disable-hang-monitor" => nil,
-          "disable-features" => "site-per-process,IsolateOrigins,TranslateUI",
+          "disable-features" => "site-per-process,IsolateOrigins,TranslateUI,MacAppCodeSignClone",
           "disable-translate" => nil,
           "disable-background-networking" => nil,
           "enable-features" => "NetworkService,NetworkServiceInProcess",


### PR DESCRIPTION
This prevents the creation of /private/var/folders/*/*/*/com.google.Chrome.code_sign_clone folders, that end up taking a heavy storage space on macOS; see https://github.com/teamcapybara/capybara/issues/2795#issuecomment-3144417933

This was previoulsy reported for Ferrum in #500.

I haven't seen specifics specs for default browser options, so I only adjusted them and added details in the commit message to document the change. Feel free to ask for more changes if need be; while I am not used to developing gems if you have some pointers to improve this PR I'm all ears.