### PR TITLE
Prevent initialization failure

### DIFF
--- a/lib/ferrum/browser/options/chrome.rb
+++ b/lib/ferrum/browser/options/chrome.rb
@@ -95,7 +95,7 @@ module Ferrum
         end
 
         def merge_default(flags, options)
-          defaults = options.headless == false ? except("headless", "disable-gpu") : DEFAULT_OPTIONS
+          defaults = options.headless == false ? except("headless", "disable-gpu") : DEFAULT_OPTIONS.dup
           defaults.delete("no-startup-window") if options.incognito == false
 
           if options.dockerize || ENV["FERRUM_CHROME_DOCKERIZE"] == "true"


### PR DESCRIPTION
Hi,
Fix for `can't modify frozen Hash` issue when initializing with `incognito: false` option.