### PR TITLE
fix: Browser#create_page ensure block masks original error with NoMethodError

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -172,7 +172,7 @@ module Ferrum
     ensure
       if block_given?
         page&.close
-        context.dispose if new_context
+        context&.dispose if new_context
       end
     end
 

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -580,6 +580,17 @@ describe Ferrum::Browser do
 
         expect(browser.contexts.size).to eq(0)
       end
+
+      it "propagates the original error when context creation fails inside the block form" do
+        original_error = Ferrum::DeadBrowserError.new("simulated browser death")
+        allow(browser.contexts).to receive(:create).and_raise(original_error)
+
+        expect do
+          browser.create_page(new_context: true) do |page|
+            page.go_to("/simple")
+          end
+        end.to raise_error(Ferrum::DeadBrowserError, "simulated browser death")
+      end
     end
 
     context "with :proxy" do


### PR DESCRIPTION
## Problem

When `Browser#create_page` is called with `new_context: true` and a block, an exception raised by `contexts.create(...)` (for example `Ferrum::DeadBrowserError` when the browser dies before the context is created) is masked by a `NoMethodError` from the `ensure` block.

The local `context` is `nil` at that point because the assignment never completed. The `ensure` block then calls `context.dispose` unconditionally and raises `NoMethodError: undefined method 'dispose' for nil`, which propagates in place of the original error. Callers who rescue `Ferrum::Error` (the gem's documented contract) won't catch the masked `NoMethodError`, so legitimate errors like `DeadBrowserError` slip past their handlers.

## Fix

The adjacent cleanup of `page` already uses safe navigation (`page&.close`) for the same reason; this just makes `context.dispose` symmetric.

A regression spec stubs `browser.contexts.create` to raise `Ferrum::DeadBrowserError` and asserts the original error propagates through the block form. Without the fix it fails with `expected Ferrum::DeadBrowserError ... got NoMethodError: undefined method 'dispose' for nil`.