### PR TITLE
Add opt-in wait_for_pending_js: option to clicks (and FERRUM_WAIT_FOR_PENDING_JS env var)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - `Ferrum::Mouse#click` and `Ferrum::Node#click` accept `wait_for_pending_js:` to drain pending JS microtasks after the click [#586]
+- `Ferrum::Mouse::WAIT_FOR_PENDING_JS` (set by `FERRUM_WAIT_FOR_PENDING_JS`, default `false`) sets the project-wide default for `wait_for_pending_js:`. Read once at load time, so the env var must be set before `require "ferrum"` (e.g. before `require "capybara/cuprite"`) [#586]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased](https://github.com/rubycdp/ferrum/compare/v0.17.2...main) ##
 
 ### Added
+- `Ferrum::Mouse#click` and `Ferrum::Node#click` accept `wait_for_pending_js:` to drain pending JS microtasks after the click [#586]
 
 ### Changed
 

--- a/lib/ferrum/mouse.rb
+++ b/lib/ferrum/mouse.rb
@@ -66,6 +66,13 @@ module Ferrum
     #
     # @param [Float] wait
     #
+    # @param [Boolean] wait_for_pending_js
+    #   When `true`, follows the click with a no-op `Runtime.evaluate` so the
+    #   renderer's microtask checkpoint runs before this method returns.
+    #   Useful when a click handler depends on state set inside a `.then()`
+    #   chain (for example, a dynamically `import()`-ed Stimulus controller).
+    #   Defaults to `false`, preserving the historical behavior.
+    #
     # @param [Hash{Symbol => Object}] options
     #   Additional keyword arguments.
     #
@@ -79,13 +86,14 @@ module Ferrum
     #
     # @return [self]
     #
-    def click(x:, y:, delay: 0, wait: CLICK_WAIT, **options)
+    def click(x:, y:, delay: 0, wait: CLICK_WAIT, wait_for_pending_js: false, **options)
       move(x: x, y: y)
       down(**options)
       sleep(delay)
       # Potential wait because if some network event is triggered then we have
       # to wait until it's over and frame is loaded or failed to load.
       up(wait: wait, **options)
+      wait_for_pending_js! if wait_for_pending_js
       self
     end
 
@@ -163,6 +171,13 @@ module Ferrum
     end
 
     private
+
+    # Forces the renderer's microtask checkpoint to drain before this call
+    # returns by issuing a no-op `Runtime.evaluate`. Private because the
+    # `wait_for_pending_js:` kwarg on `#click` is the public surface.
+    def wait_for_pending_js!
+      @page.command("Runtime.evaluate", expression: "")
+    end
 
     def mouse_event(type:, button: :left, count: 1, modifiers: nil, wait: 0)
       button = validate_button(button)

--- a/lib/ferrum/mouse.rb
+++ b/lib/ferrum/mouse.rb
@@ -3,6 +3,7 @@
 module Ferrum
   class Mouse
     CLICK_WAIT = ENV.fetch("FERRUM_CLICK_WAIT", 0.1).to_f
+    WAIT_FOR_PENDING_JS = ENV.fetch("FERRUM_WAIT_FOR_PENDING_JS", "false") == "true"
     BUTTON_MASKS = {
       "none" => 0,
       "left" => 1,
@@ -66,12 +67,16 @@ module Ferrum
     #
     # @param [Float] wait
     #
-    # @param [Boolean] wait_for_pending_js
+    # @param [Boolean, nil] wait_for_pending_js
     #   When `true`, follows the click with a no-op `Runtime.evaluate` so the
     #   renderer's microtask checkpoint runs before this method returns.
     #   Useful when a click handler depends on state set inside a `.then()`
     #   chain (for example, a dynamically `import()`-ed Stimulus controller).
-    #   Defaults to `false`, preserving the historical behavior.
+    #
+    #   When `nil` (the default), resolves to {WAIT_FOR_PENDING_JS}, which is
+    #   driven by the `FERRUM_WAIT_FOR_PENDING_JS` env var. Set the env var
+    #   to `"true"` before requiring ferrum to flip the project-wide default.
+    #   It is read once at load time.
     #
     # @param [Hash{Symbol => Object}] options
     #   Additional keyword arguments.
@@ -86,14 +91,15 @@ module Ferrum
     #
     # @return [self]
     #
-    def click(x:, y:, delay: 0, wait: CLICK_WAIT, wait_for_pending_js: false, **options)
+    def click(x:, y:, delay: 0, wait: CLICK_WAIT, wait_for_pending_js: nil, **options)
+      should_wait = wait_for_pending_js.nil? ? WAIT_FOR_PENDING_JS : wait_for_pending_js
       move(x: x, y: y)
       down(**options)
       sleep(delay)
       # Potential wait because if some network event is triggered then we have
       # to wait until it's over and frame is loaded or failed to load.
       up(wait: wait, **options)
-      wait_for_pending_js! if wait_for_pending_js
+      wait_for_pending_js! if should_wait
       self
     end
 

--- a/lib/ferrum/node.rb
+++ b/lib/ferrum/node.rb
@@ -64,6 +64,9 @@ module Ferrum
     # keys: (:alt, (:ctrl | :control), (:meta | :command), :shift)
     # offset: { :x, :y, :position (:top | :center) }
     # wait_for_pending_js: see Mouse#click. Applies to all click modes.
+    #   Default `nil` resolves to Mouse::WAIT_FOR_PENDING_JS so a single
+    #   FERRUM_WAIT_FOR_PENDING_JS setting covers both layers. Explicit
+    #   true/false at the call site wins over the env-var default.
     #
     # All three modes delegate to Mouse#click so `wait_for_pending_js:` lives
     # in one place. The `:right` and `:double` modes pass `wait: 0` to
@@ -71,7 +74,7 @@ module Ferrum
     # non-primary buttons; `:left` uses Mouse#click's default `wait: CLICK_WAIT`
     # because Capybara has historically relied on the primary click to block
     # for short navigations.
-    def click(mode: :left, keys: [], offset: {}, delay: 0, wait_for_pending_js: false)
+    def click(mode: :left, keys: [], offset: {}, delay: 0, wait_for_pending_js: nil)
       x, y = find_position(**offset)
       modifiers = page.keyboard.modifiers(keys)
 

--- a/lib/ferrum/node.rb
+++ b/lib/ferrum/node.rb
@@ -63,23 +63,28 @@ module Ferrum
     # mode: (:left | :right | :double)
     # keys: (:alt, (:ctrl | :control), (:meta | :command), :shift)
     # offset: { :x, :y, :position (:top | :center) }
-    def click(mode: :left, keys: [], offset: {}, delay: 0)
+    # wait_for_pending_js: see Mouse#click. Applies to all click modes.
+    #
+    # All three modes delegate to Mouse#click so `wait_for_pending_js:` lives
+    # in one place. The `:right` and `:double` modes pass `wait: 0` to
+    # preserve the historical no-network-wait behavior of `Node#click` for
+    # non-primary buttons; `:left` uses Mouse#click's default `wait: CLICK_WAIT`
+    # because Capybara has historically relied on the primary click to block
+    # for short navigations.
+    def click(mode: :left, keys: [], offset: {}, delay: 0, wait_for_pending_js: false)
       x, y = find_position(**offset)
       modifiers = page.keyboard.modifiers(keys)
 
       case mode
       when :right
-        page.mouse.move(x: x, y: y)
-        page.mouse.down(button: :right, modifiers: modifiers)
-        sleep(delay)
-        page.mouse.up(button: :right, modifiers: modifiers)
+        page.mouse.click(x: x, y: y, button: :right, modifiers: modifiers, delay: delay,
+                         wait: 0, wait_for_pending_js: wait_for_pending_js)
       when :double
-        page.mouse.move(x: x, y: y)
-        page.mouse.down(modifiers: modifiers, count: 2)
-        sleep(delay)
-        page.mouse.up(modifiers: modifiers, count: 2)
+        page.mouse.click(x: x, y: y, count: 2, modifiers: modifiers, delay: delay,
+                         wait: 0, wait_for_pending_js: wait_for_pending_js)
       when :left
-        page.mouse.click(x: x, y: y, modifiers: modifiers, delay: delay)
+        page.mouse.click(x: x, y: y, modifiers: modifiers, delay: delay,
+                         wait_for_pending_js: wait_for_pending_js)
       end
 
       self

--- a/sig/ferrum/mouse.rbs
+++ b/sig/ferrum/mouse.rbs
@@ -2,6 +2,8 @@ module Ferrum
   class Mouse
     CLICK_WAIT: ::Float
 
+    WAIT_FOR_PENDING_JS: bool
+
     BUTTON_MASKS: ::Hash[String, ::Integer]
 
     @page: Page
@@ -15,7 +17,7 @@ module Ferrum
 
     def scroll_to: (::Numeric top, ::Numeric left) -> self
 
-    def click: (x: ::Numeric, y: ::Numeric, ?delay: ::Numeric, ?wait: ::Numeric, ?wait_for_pending_js: bool, ?button: Symbol, ?count: ::Integer, ?modifiers: ::Integer) -> self
+    def click: (x: ::Numeric, y: ::Numeric, ?delay: ::Numeric, ?wait: ::Numeric, ?wait_for_pending_js: bool?, ?button: Symbol, ?count: ::Integer, ?modifiers: ::Integer) -> self
 
     def down: (?button: Symbol, ?count: ::Integer, ?modifiers: ::Integer) -> self
 

--- a/sig/ferrum/mouse.rbs
+++ b/sig/ferrum/mouse.rbs
@@ -15,7 +15,7 @@ module Ferrum
 
     def scroll_to: (::Numeric top, ::Numeric left) -> self
 
-    def click: (x: ::Numeric, y: ::Numeric, ?delay: ::Numeric, ?wait: ::Numeric, ?button: Symbol, ?count: ::Integer, ?modifiers: ::Integer) -> self
+    def click: (x: ::Numeric, y: ::Numeric, ?delay: ::Numeric, ?wait: ::Numeric, ?wait_for_pending_js: bool, ?button: Symbol, ?count: ::Integer, ?modifiers: ::Integer) -> self
 
     def down: (?button: Symbol, ?count: ::Integer, ?modifiers: ::Integer) -> self
 
@@ -24,6 +24,8 @@ module Ferrum
     def move: (x: ::Numeric, y: ::Numeric, ?steps: ::Integer) -> self
 
     private
+
+    def wait_for_pending_js!: () -> Hash[String, untyped]
 
     def mouse_event: (type: String, ?button: Symbol, ?count: ::Integer, ?modifiers: ::Integer?, ?wait: ::Numeric) -> Hash[String, untyped]
 

--- a/sig/ferrum/node.rbs
+++ b/sig/ferrum/node.rbs
@@ -34,7 +34,7 @@ module Ferrum
 
     def type: (*untyped keys) -> untyped
 
-    def click: (?mode: ::Symbol, ?keys: untyped, ?offset: ::Hash[untyped, untyped], ?delay: ::Integer, ?wait_for_pending_js: bool) -> self
+    def click: (?mode: ::Symbol, ?keys: untyped, ?offset: ::Hash[untyped, untyped], ?delay: ::Integer, ?wait_for_pending_js: bool?) -> self
 
     def hover: () -> untyped
 

--- a/sig/ferrum/node.rbs
+++ b/sig/ferrum/node.rbs
@@ -34,7 +34,7 @@ module Ferrum
 
     def type: (*untyped keys) -> untyped
 
-    def click: (?mode: ::Symbol, ?keys: untyped, ?offset: ::Hash[untyped, untyped], ?delay: ::Integer) -> self
+    def click: (?mode: ::Symbol, ?keys: untyped, ?offset: ::Hash[untyped, untyped], ?delay: ::Integer, ?wait_for_pending_js: bool) -> self
 
     def hover: () -> untyped
 

--- a/spec/mouse_spec.rb
+++ b/spec/mouse_spec.rb
@@ -30,6 +30,57 @@ describe Ferrum::Mouse do
       browser.at_xpath("//a[text() = 'Link']").click
       expect(browser.body).to include("Hello world")
     end
+
+    # Regression specs for [#584]. The bug: Input.dispatchMouseEvent returns
+    # before the renderer has run any microtasks queued behind the click (for
+    # example, a Stimulus controller registered inside import().then(...)). We
+    # can't observe this from a black-box DOM assertion because every ferrum
+    # DOM read goes through Runtime.*, which itself drains microtasks. Instead,
+    # spy on Page#command and assert that Runtime.evaluate is or isn't issued
+    # after the click depending on the option.
+    context "with wait_for_pending_js: option" do
+      before { browser.go_to("/click_coordinates") }
+
+      it "issues a no-op Runtime.evaluate after the click when true" do
+        allow(browser.page).to receive(:command).and_call_original
+
+        browser.mouse.click(x: 100, y: 150, wait_for_pending_js: true)
+
+        expect(browser.page).to have_received(:command).with("Runtime.evaluate", expression: "")
+      end
+
+      it "does not issue Runtime.evaluate by default" do
+        allow(browser.page).to receive(:command).and_call_original
+
+        browser.mouse.click(x: 100, y: 150)
+
+        expect(browser.page).not_to have_received(:command).with("Runtime.evaluate", expression: "")
+      end
+
+      it "is threaded through Node#click for :left mode" do
+        allow(browser.page).to receive(:command).and_call_original
+
+        browser.at_xpath("//body").click(wait_for_pending_js: true)
+
+        expect(browser.page).to have_received(:command).with("Runtime.evaluate", expression: "")
+      end
+
+      it "is threaded through Node#click for :right mode" do
+        allow(browser.page).to receive(:command).and_call_original
+
+        browser.at_xpath("//body").click(mode: :right, wait_for_pending_js: true)
+
+        expect(browser.page).to have_received(:command).with("Runtime.evaluate", expression: "")
+      end
+
+      it "is threaded through Node#click for :double mode" do
+        allow(browser.page).to receive(:command).and_call_original
+
+        browser.at_xpath("//body").click(mode: :double, wait_for_pending_js: true)
+
+        expect(browser.page).to have_received(:command).with("Runtime.evaluate", expression: "")
+      end
+    end
   end
 
   describe "#scroll_by" do

--- a/spec/mouse_spec.rb
+++ b/spec/mouse_spec.rb
@@ -50,6 +50,9 @@ describe Ferrum::Mouse do
       end
 
       it "does not issue Runtime.evaluate by default" do
+        # Explicitly stub so the spec is deterministic regardless of whether
+        # FERRUM_WAIT_FOR_PENDING_JS is set in the developer's environment.
+        stub_const("Ferrum::Mouse::WAIT_FOR_PENDING_JS", false)
         allow(browser.page).to receive(:command).and_call_original
 
         browser.mouse.click(x: 100, y: 150)
@@ -79,6 +82,61 @@ describe Ferrum::Mouse do
         browser.at_xpath("//body").click(mode: :double, wait_for_pending_js: true)
 
         expect(browser.page).to have_received(:command).with("Runtime.evaluate", expression: "")
+      end
+    end
+
+    # The FERRUM_WAIT_FOR_PENDING_JS env var is read once at require time
+    # into Mouse::WAIT_FOR_PENDING_JS. Use stub_const to flip it. The
+    # Node#click default of `wait_for_pending_js: nil` also resolves to this
+    # constant (via Mouse#click's resolution), so one env-var setting covers
+    # both layers.
+    context "with FERRUM_WAIT_FOR_PENDING_JS env var" do
+      it "Ferrum::Mouse::WAIT_FOR_PENDING_JS is false by default",
+         skip: (ENV["FERRUM_WAIT_FOR_PENDING_JS"] == "true" ? "skipped: FERRUM_WAIT_FOR_PENDING_JS=true" : false) do
+        # Documents the contract: default off unless opted in. Skips (rather
+        # than fails) when the developer has opted in via env var, so the
+        # ferrum suite doesn't break in environments that exercise that path.
+        expect(Ferrum::Mouse::WAIT_FOR_PENDING_JS).to be(false)
+      end
+
+      it "flips the default for Mouse#click when set to true" do
+        stub_const("Ferrum::Mouse::WAIT_FOR_PENDING_JS", true)
+        browser.go_to("/click_coordinates")
+        allow(browser.page).to receive(:command).and_call_original
+
+        browser.mouse.click(x: 100, y: 150)
+
+        expect(browser.page).to have_received(:command).with("Runtime.evaluate", expression: "")
+      end
+
+      it "flips the default for Node#click when set to true" do
+        stub_const("Ferrum::Mouse::WAIT_FOR_PENDING_JS", true)
+        browser.go_to("/click_coordinates")
+        allow(browser.page).to receive(:command).and_call_original
+
+        browser.at_xpath("//body").click
+
+        expect(browser.page).to have_received(:command).with("Runtime.evaluate", expression: "")
+      end
+
+      it "lets an explicit wait_for_pending_js: false at the call site beat the env-var default" do
+        stub_const("Ferrum::Mouse::WAIT_FOR_PENDING_JS", true)
+        browser.go_to("/click_coordinates")
+        allow(browser.page).to receive(:command).and_call_original
+
+        browser.mouse.click(x: 100, y: 150, wait_for_pending_js: false)
+
+        expect(browser.page).not_to have_received(:command).with("Runtime.evaluate", expression: "")
+      end
+
+      it "lets an explicit wait_for_pending_js: false on Node#click beat the env-var default" do
+        stub_const("Ferrum::Mouse::WAIT_FOR_PENDING_JS", true)
+        browser.go_to("/click_coordinates")
+        allow(browser.page).to receive(:command).and_call_original
+
+        browser.at_xpath("//body").click(wait_for_pending_js: false)
+
+        expect(browser.page).not_to have_received(:command).with("Runtime.evaluate", expression: "")
       end
     end
   end


### PR DESCRIPTION
Refs #584.

## tl;dr

`Mouse#click` returns before pending JS microtasks drain, which causes flaky tests when a click handler depends on a dynamic `import()` resolving (the Stimulus + esbuild pattern). This PR adds an opt-in `wait_for_pending_js:` kwarg on `Mouse#click` and `Node#click`. When set, the click is followed by a no-op `Runtime.evaluate` so the renderer's microtask checkpoint runs before the call returns. `FERRUM_WAIT_FOR_PENDING_JS=true` flips the default project-wide. Default stays `false`, so existing suites see zero behavior change.

Two atomic commits, RBS signatures updated, 13 new specs that spy on the CDP message log.

## Problem

`Mouse#click` issues three `Input.dispatchMouseEvent` CDP commands (mouseMoved, mousePressed, mouseReleased) and returns. The mouseReleased ack returns before the renderer has run microtasks queued behind the click. A common pattern that hits this:

```js
import("./controller").then(({ default: Controller }) => {
  application.register("my-controller", Controller);
});
```

The Stimulus controller's `connect` callback registers the click handler inside the resolved `.then()`. On fast machines the microtask finishes before the next ferrum call; on slower CI the click lands before the handler attaches and the test fails.

The reporter on #584 independently identified the fix shape (no-op `Runtime.evaluate` after the click, which forces the renderer's microtask checkpoint to run before the CDP ack returns).

## Approach

Two atomic commits so the maintainer can land them independently.

### Commit 1: `wait_for_pending_js:` kwarg on `Mouse#click` and `Node#click`

Adds an opt-in kwarg (default `false`). When `true`, follows the click with `Runtime.evaluate(expression: "")`.

```ruby
page.mouse.click(x: x, y: y, wait_for_pending_js: true)
page.at_css("#btn").click(wait_for_pending_js: true)
page.at_css("#btn").click(mode: :right, wait_for_pending_js: true)
page.at_css("#btn").click(mode: :double, wait_for_pending_js: true)
```

`Node#click` now delegates all three modes (`:left`, `:right`, `:double`) to `Mouse#click` so the wait logic lives in one place. `:right` passes `button: :right`, `:double` passes `count: 2`; both pass `wait: 0` to preserve the historical no-network-wait behavior for non-primary clicks (`Mouse#click`'s default `wait: CLICK_WAIT` is preserved for `:left`, which Capybara has historically relied on to block for short navigations). A comment in `Node#click` marks this trade-off.

The flush itself is a private `Mouse#wait_for_pending_js!` method; the public surface is the kwarg on `Mouse#click`. Since `Node#click` delegates, it doesn't need access to the helper.

The kwarg is named after the caller's intent (wait until pending JS settles), not the mechanism (a no-op `Runtime.evaluate` that forces the renderer's microtask checkpoint). If the implementation later switches to `Runtime.awaitPromise` or another barrier, the API still reads correctly.

Opt-in default preserves the historical perf profile for every existing suite. No surprise extra round-trip per click. Users who hit this bug can opt in per call site.

### Commit 2: `FERRUM_WAIT_FOR_PENDING_JS` env var as the default

Mirrors the existing `FERRUM_CLICK_WAIT` / `CLICK_WAIT` pattern at the top of `Mouse` (`mouse.rb:5`). Lets downstream projects (e.g. Cuprite-based suites) flip the default once at boot from a config file instead of plumbing the kwarg through every call site:

```ruby
# config/cuprite.rb (or equivalent; run before the gem loads)
ENV["FERRUM_WAIT_FOR_PENDING_JS"] ||= "true"
require "capybara/cuprite"
```

Exposed as `Ferrum::Mouse::WAIT_FOR_PENDING_JS`. Both `Mouse#click` and `Node#click` default their `wait_for_pending_js:` kwarg to `nil`; `nil` resolves to the constant. Because `Node#click` delegates to `Mouse#click`, the resolution happens in one place. Explicit `true`/`false` at the call site overrides the env-var-flipped default. Specs cover both layers.

The env var is read once at load time, which matches `FERRUM_CLICK_WAIT`. The CHANGELOG entry calls this out so Rails users don't quietly put it in an initializer that runs after `require "ferrum"`.

## Test strategy

The CDP-spy approach is deliberate. An earlier version of this PR asserted on post-click DOM state via `node.text`, but `node.text` goes through `Runtime.callFunctionOn`, which itself drains microtasks. The assertion passed regardless of whether `Mouse#click` issued the extra `Runtime.evaluate`. The test was decorative.

The current specs spy on `Page#command` (the same object `Mouse#click` reaches `@page.command` on) and assert the message log contains or doesn't contain `Runtime.evaluate(expression: "")`. Reverting the conditional flush fails every "must issue" spec.

Default-off specs explicitly `stub_const("Ferrum::Mouse::WAIT_FOR_PENDING_JS", false)` so they pass regardless of the developer's env. The constant-default spec (`be(false)`) gracefully skips when `FERRUM_WAIT_FOR_PENDING_JS=true` is set rather than failing, so developers exercising the opted-in path don't see the ferrum suite break.

## Files

- `lib/ferrum/mouse.rb`: `WAIT_FOR_PENDING_JS` constant, `wait_for_pending_js:` kwarg with `nil` sentinel, private `wait_for_pending_js!` helper.
- `lib/ferrum/node.rb`: all click modes (`:left`, `:right`, `:double`) delegate to `Mouse#click`; `wait_for_pending_js:` threaded through; `:right`/`:double` pass `wait: 0` to preserve historical semantics.
- `sig/ferrum/mouse.rbs`, `sig/ferrum/node.rbs`: RBS signatures updated for the new constant and kwarg (`bool?` on both layers); private helper signature under the `private` section.
- `spec/mouse_spec.rb`: 13 specs covering kwarg-on, kwarg-off (with env guard), all three Node modes, env-var Mouse default, env-var Node default, explicit-false-beats-env at both layers, and a contract spec for the constant's default.
- `CHANGELOG.md`: two entries under `[Unreleased] -> Added`.

## Alternatives considered

**Default-on**. Skipped to avoid changing the perf profile of existing suites without consent. Each click adds one extra CDP round-trip when enabled. Happy to provide measurements if you would prefer default-on.

**Class accessor (`Ferrum::Mouse.wait_for_pending_js_by_default = true`)**. Skipped because ferrum has no existing `.configure` pattern and the env var mirrors `FERRUM_CLICK_WAIT` exactly. Class accessor would work too if you would rather.

**Naming alternatives**. `flush_microtasks:` named the mechanism rather than the intent and would have aged poorly if the implementation later changed to `Runtime.awaitPromise` or another barrier; renamed to `wait_for_pending_js:` for that reason. Open to other names if you have a preference (`wait_for_js:`, `await_js:`, etc.).

## Self-review

Earlier review passes on this PR missed real issues that surfaced on subsequent passes. Posted as a comment for the paper trail and folded into this version. Notable items addressed before this push:

- The two layers used inconsistent semantics for `wait_for_pending_js: nil` (silent-disable on `Mouse`, env-var resolution on `Node`). Both now use the same `nil` sentinel, and `Node#click` delegates the resolution to `Mouse#click` so it only happens in one place.
- `Node#click` originally duplicated the `Runtime.evaluate(expression: "")` string literal that `Mouse#click` also issued. Refactored so `Node#click` delegates all three modes to `Mouse#click`; the helper became private as a free consequence.
- `Node#click`'s env-var integration had no spec.
- Default-off specs were vulnerable to the developer's environment.
- The kwarg was originally named `flush_microtasks:`, which named the mechanism rather than the intent. Renamed to `wait_for_pending_js:` so the API survives an implementation change.