### PR TITLE
fix: align pending_connection_errors YARD default with implementation

### DIFF
--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -81,7 +81,7 @@ module Ferrum
     # @option options [Boolean] :js_errors
     #   When true, JavaScript errors get re-raised in Ruby.
     #
-    # @option options [Boolean] :pending_connection_errors (false)
+    # @option options [Boolean] :pending_connection_errors (true)
     #   When main frame is still waiting for slow responses while timeout is
     #   reached {PendingConnectionsError} is raised. It's better to figure out
     #   why you have slow responses and fix or block them rather than turn this


### PR DESCRIPTION
## Summary

Fixes an outdated YARD default for `:pending_connection_errors` on `Ferrum::Browser`.

| Location | Documented default | Actual default |
|----------|-------------------|----------------|
| `lib/ferrum/browser.rb` (before) | `false` | — |
| `lib/ferrum/browser/options.rb` | — | `true` |
| `docs/2-customization.md` | `true` | `true` |

This PR aligns `browser.rb` with the implementation and existing docs.

## Background

- #561 set `:pending_connection_errors` default to `false`
- #572 reverted the default to `true` and updated `options.rb` and `docs/2-customization.md`
- `lib/ferrum/browser.rb` YARD was not updated in #572

## Test plan

- [x] No code behavior changes
- [x] Verified against `options.rb` and customization docs