### PR TITLE
feat: add `page.accessibility` CDP domain API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `Ferrum::Frame#loader_id` provides a loader id when frame navigates [#583]
 - `Ferrum::Frame#lifecycle_events` provides a list of frame's events like init, networkIdle, firstPaint, etc. [#583]
 - `Ferrum::Frame#idle?` whether frame was loaded [#583]
+- `page.accessibility` API and `Node#axnode` for reading the CDP accessibility tree
 
 ### Changed
 - `Ferrum::PendingConnectionsError` and `Ferrum::TimeoutError` were swallowed even though happening when traffic iterator results in empty array. [#583]

--- a/lib/ferrum/accessibility.rb
+++ b/lib/ferrum/accessibility.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "ferrum/accessibility/ax_node"
+
+module Ferrum
+  #
+  # Wraps the CDP [Accessibility](https://chromedevtools.github.io/devtools-protocol/tot/Accessibility/)
+  # domain. The query commands work without `enable`; `enable`/`disable` are
+  # provided for completeness (live AX events).
+  #
+  # @note The node-scoped methods (`node_for`, `partial_tree`, `query` with a
+  #   `node:`) issue the command against the node's owning page session. They
+  #   support same-process (same-target) iframes; nodes living in an
+  #   out-of-process iframe (OOPIF, separate CDP target) are not resolvable and
+  #   will error or return an empty result.
+  #
+  class Accessibility
+    def initialize(page)
+      @page = page
+    end
+
+    #
+    # The single non-ignored AXNode for a DOM node, or `nil`.
+    #
+    # @param [Ferrum::Node] node
+    # @return [AXNode, nil]
+    #
+    def node_for(node)
+      partial_tree(node: node).find { |ax_node| !ax_node.ignored? }
+    end
+
+    #
+    # The partial AX tree for a DOM node.
+    #
+    # @param [Ferrum::Node] node
+    # @param [Boolean] fetch_relatives
+    # @return [Array<AXNode>]
+    #
+    def partial_tree(node:, fetch_relatives: false)
+      nodes = node.page.command("Accessibility.getPartialAXTree",
+                                nodeId: node.node_id,
+                                fetchRelatives: fetch_relatives)["nodes"]
+      build(nodes)
+    end
+
+    #
+    # The full AX tree for the page.
+    #
+    # @param [Integer, nil] depth
+    # @param [String, nil] frame_id
+    # @return [Array<AXNode>]
+    #
+    def snapshot(depth: nil, frame_id: nil)
+      params = { depth: depth, frameId: frame_id }.compact
+      build(@page.command("Accessibility.getFullAXTree", **params)["nodes"])
+    end
+
+    #
+    # Query the AX tree by accessible name and/or role.
+    #
+    # @param [String, nil] name
+    # @param [String, nil] role
+    # @param [Ferrum::Node, nil] node  Scope the query to this node's subtree.
+    # @return [Array<AXNode>]
+    #
+    def query(name: nil, role: nil, node: nil)
+      page = node ? node.page : @page
+      params = { accessibleName: name, role: role }.compact
+      params[:nodeId] = node ? node.node_id : page.document_node_id
+      build(page.command("Accessibility.queryAXTree", **params)["nodes"])
+    end
+
+    #
+    # The root AXNode of the (optionally framed) document.
+    #
+    # @param [String, nil] frame_id
+    # @return [AXNode, nil]
+    #
+    def root(frame_id: nil)
+      params = { depth: 1, frameId: frame_id }.compact
+      build(@page.command("Accessibility.getFullAXTree", **params)["nodes"]).first
+    end
+
+    # @return [self]
+    def enable
+      @page.command("Accessibility.enable")
+      self
+    end
+
+    # @return [self]
+    def disable
+      @page.command("Accessibility.disable")
+      self
+    end
+
+    private
+
+    def build(nodes)
+      Array(nodes).map { |node| AXNode.new(node) }
+    end
+  end
+end

--- a/lib/ferrum/accessibility/ax_node.rb
+++ b/lib/ferrum/accessibility/ax_node.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Ferrum
+  class Accessibility
+    #
+    # Represents an [AXNode](https://chromedevtools.github.io/devtools-protocol/tot/Accessibility/#type-AXNode)
+    # from the CDP Accessibility domain.
+    #
+    class AXNode
+      #
+      # @param [Hash{String => Object}] params
+      #   The parsed CDP AXNode attributes.
+      #
+      def initialize(params)
+        @params = deep_freeze(params)
+      end
+
+      # @return [String, nil]
+      def role
+        @params.dig("role", "value")
+      end
+
+      # @return [String, nil]
+      def name
+        @params.dig("name", "value")
+      end
+
+      # @return [String, nil]
+      def description
+        @params.dig("description", "value")
+      end
+
+      # @return [String, Numeric, Boolean, nil] raw CDP AXValue.value; type varies by control
+      def value
+        @params.dig("value", "value")
+      end
+
+      # @return [Hash{String => Object}]
+      #   ARIA/computed properties flattened to `name => value`.
+      def properties
+        @properties ||= Array(@params["properties"]).to_h do |property|
+          [property["name"], property.dig("value", "value")]
+        end.freeze
+      end
+
+      # @return [Boolean]
+      def ignored?
+        @params["ignored"] == true
+      end
+
+      # @return [Array, nil]
+      def ignored_reasons
+        @params["ignoredReasons"]
+      end
+
+      # @return [String, nil]
+      def node_id
+        @params["nodeId"]
+      end
+
+      # @return [Integer, nil]
+      def backend_dom_node_id
+        @params["backendDOMNodeId"]
+      end
+
+      # @return [Array, nil]
+      def child_ids
+        @params["childIds"]
+      end
+
+      # @return [Hash]
+      #   The raw CDP AXNode hash.
+      def to_h
+        @params
+      end
+
+      private
+
+      def deep_freeze(object)
+        case object
+        when Hash  then object.each { |key, value| deep_freeze(key.freeze) && deep_freeze(value) }
+        when Array then object.each { |value| deep_freeze(value) }
+        end
+        object.freeze
+      end
+    end
+  end
+end

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -21,7 +21,7 @@ module Ferrum
     delegate %i[go_to goto go back forward refresh reload stop wait_for_reload
                 at_css at_xpath css xpath current_url current_title url title
                 body doctype content=
-                headers cookies network downloads
+                headers cookies network accessibility downloads
                 mouse keyboard
                 screenshot pdf mhtml viewport_size device_pixel_ratio
                 start_screencast stop_screencast

--- a/lib/ferrum/node.rb
+++ b/lib/ferrum/node.rb
@@ -229,6 +229,14 @@ module Ferrum
         .each_with_object({}) { |style, memo| memo.merge!(style["name"] => style["value"]) }
     end
 
+    # Returns the computed accessibility node for the element, or nil if the
+    # element is ignored by the accessibility tree.
+    #
+    # @return [Accessibility::AXNode, nil]
+    def axnode
+      page.accessibility.node_for(self)
+    end
+
     def remove
       page.command("DOM.removeNode", nodeId: node_id)
     end

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -8,6 +8,7 @@ require "ferrum/headers"
 require "ferrum/cookies"
 require "ferrum/dialog"
 require "ferrum/network"
+require "ferrum/accessibility"
 require "ferrum/downloads"
 require "ferrum/page/frames"
 require "ferrum/page/screencast"
@@ -57,6 +58,11 @@ module Ferrum
     # @return [Network]
     attr_reader :network
 
+    # Accessibility object.
+    #
+    # @return [Accessibility]
+    attr_reader :accessibility
+
     # Headers object.
     #
     # @return [Headers]
@@ -88,6 +94,7 @@ module Ferrum
       @headers = Headers.new(self)
       @cookies = Cookies.new(self)
       @network = Network.new(self)
+      @accessibility = Accessibility.new(self)
       @tracing = Tracing.new(self)
       @downloads = Downloads.new(self)
 

--- a/sig/ferrum/accessibility.rbs
+++ b/sig/ferrum/accessibility.rbs
@@ -1,0 +1,25 @@
+module Ferrum
+  class Accessibility
+    @page: Page
+
+    def initialize: (Page page) -> void
+
+    def node_for: (Node node) -> AXNode?
+
+    def partial_tree: (node: Node, ?fetch_relatives: bool) -> Array[AXNode]
+
+    def snapshot: (?depth: Integer?, ?frame_id: String?) -> Array[AXNode]
+
+    def query: (?name: String?, ?role: String?, ?node: Node?) -> Array[AXNode]
+
+    def root: (?frame_id: String?) -> AXNode?
+
+    def enable: () -> self
+
+    def disable: () -> self
+
+    private
+
+    def build: (Array[untyped]? nodes) -> Array[AXNode]
+  end
+end

--- a/sig/ferrum/accessibility/ax_node.rbs
+++ b/sig/ferrum/accessibility/ax_node.rbs
@@ -1,0 +1,31 @@
+module Ferrum
+  class Accessibility
+    class AXNode
+      @params: Hash[String, untyped]
+
+      def initialize: (Hash[String, untyped] params) -> void
+
+      def role: () -> String?
+
+      def name: () -> String?
+
+      def description: () -> String?
+
+      def value: () -> (String | Numeric | bool | nil)
+
+      def properties: () -> Hash[String, untyped]
+
+      def ignored?: () -> bool
+
+      def ignored_reasons: () -> Array[untyped]?
+
+      def node_id: () -> String?
+
+      def backend_dom_node_id: () -> Integer?
+
+      def child_ids: () -> Array[String]?
+
+      def to_h: () -> Hash[String, untyped]
+    end
+  end
+end

--- a/sig/ferrum/node.rbs
+++ b/sig/ferrum/node.rbs
@@ -77,6 +77,8 @@ module Ferrum
 
     def computed_style: () -> untyped
 
+    def axnode: () -> Accessibility::AXNode?
+
     private
 
     def bounding_rect_coordinates: () -> untyped

--- a/sig/ferrum/page.rbs
+++ b/sig/ferrum/page.rbs
@@ -18,6 +18,7 @@ module Ferrum
     attr_reader mouse: Mouse
     attr_reader keyboard: Keyboard
     attr_reader network: Network
+    attr_reader accessibility: Accessibility
     attr_reader headers: Headers
     attr_reader cookies: Cookies
     attr_reader downloads: Downloads

--- a/spec/accessibility_spec.rb
+++ b/spec/accessibility_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+describe Ferrum::Accessibility do
+  describe "#node_for" do
+    before { browser.go_to("/accessibility") }
+
+    it "returns the AXNode for a DOM node" do
+      ax = browser.page.accessibility.node_for(browser.at_css("#submit"))
+
+      expect(ax).to be_a(Ferrum::Accessibility::AXNode)
+      expect(ax.role).to eq("button")
+      expect(ax.name).to eq("Send form")
+      expect(ax.description).to eq("Sends the form to the server")
+      expect(ax.properties).to include("focusable" => true, "describedby" => "hint")
+    end
+
+    it "returns nil for an ignored element" do
+      expect(browser.page.accessibility.node_for(browser.at_css("#hidden"))).to be_nil
+    end
+  end
+
+  describe "#partial_tree" do
+    before { browser.go_to("/accessibility") }
+
+    it "returns an array of AXNodes" do
+      nodes = browser.page.accessibility.partial_tree(node: browser.at_css("#submit"))
+
+      expect(nodes).to all(be_a(Ferrum::Accessibility::AXNode))
+      expect(nodes.map(&:role)).to include("button")
+    end
+  end
+
+  describe "#snapshot" do
+    before { browser.go_to("/accessibility") }
+
+    it "returns the full tree as AXNodes including a button" do
+      nodes = browser.page.accessibility.snapshot
+
+      expect(nodes).to all(be_a(Ferrum::Accessibility::AXNode))
+      expect(nodes.map(&:role)).to include("button")
+    end
+  end
+
+  describe "#query" do
+    before { browser.go_to("/accessibility") }
+
+    it "finds nodes by accessible name" do
+      nodes = browser.page.accessibility.query(name: "Send form")
+
+      expect(nodes.map(&:name)).to include("Send form")
+    end
+
+    it "scopes the query to a node's subtree — inside node is found" do
+      scope = browser.at_css("#scope")
+      nodes = browser.page.accessibility.query(name: "Inside only", node: scope)
+
+      expect(nodes.map(&:name)).to include("Inside only")
+    end
+
+    it "scopes the query to a node's subtree — outside sibling is absent" do
+      scope = browser.at_css("#scope")
+      nodes = browser.page.accessibility.query(name: "Outside only", node: scope)
+
+      expect(nodes).to be_empty
+    end
+  end
+
+  describe "across an iframe" do
+    before { browser.go_to("/accessibility_iframe") }
+
+    let(:frame_node) do
+      frame = browser.page.at_css("iframe").frame
+      frame.at_css("#child_btn")
+    end
+
+    it "node_for resolves the AXNode across the frame boundary" do
+      ax = frame_node.axnode
+
+      expect(ax).to be_a(Ferrum::Accessibility::AXNode)
+      expect(ax.role).to eq("button")
+      expect(ax.name).to eq("Frame button")
+    end
+
+    it "partial_tree returns AXNodes for a frame-resident node" do
+      nodes = browser.page.accessibility.partial_tree(node: frame_node)
+
+      expect(nodes).to all(be_a(Ferrum::Accessibility::AXNode))
+      expect(nodes).not_to be_empty
+      expect(nodes.map(&:role)).to include("button")
+      expect(nodes.map(&:name)).to include("Frame button")
+    end
+
+    it "query scoped to a frame-resident node returns the button" do
+      nodes = browser.page.accessibility.query(name: "Frame button", node: frame_node)
+
+      expect(nodes).not_to be_empty
+      expect(nodes.map(&:name)).to include("Frame button")
+    end
+  end
+
+  describe "#root" do
+    before { browser.go_to("/accessibility") }
+
+    it "returns a single root AXNode" do
+      expect(browser.page.accessibility.root).to be_a(Ferrum::Accessibility::AXNode)
+    end
+  end
+
+  describe "#value" do
+    before { browser.go_to("/accessibility") }
+
+    it "returns the raw CDP value for a range input as a Numeric (Chrome does not stringify it)" do
+      ax = browser.page.accessibility.node_for(browser.at_css("#volume"))
+      value = ax.value
+
+      # Chrome returns the range value as Integer 7, not the string "7"
+      expect(value).to eq(7)
+      expect(value).to be_a(Numeric)
+    end
+  end
+
+  it "is reachable from the browser" do
+    expect(browser.accessibility).to be_a(described_class)
+  end
+end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -368,6 +368,22 @@ describe Ferrum::Node do
     end
   end
 
+  describe "#axnode" do
+    before { browser.go_to("/accessibility") }
+
+    it "returns the AXNode for the element" do
+      ax = browser.at_css("#submit").axnode
+
+      expect(ax).to be_a(Ferrum::Accessibility::AXNode)
+      expect(ax.role).to eq("button")
+      expect(ax.name).to eq("Send form")
+    end
+
+    it "returns nil for an ignored element" do
+      expect(browser.at_css("#hidden").axnode).to be_nil
+    end
+  end
+
   describe "#remove" do
     it "removes node" do
       browser.go_to("/simple")

--- a/spec/support/views/accessibility.erb
+++ b/spec/support/views/accessibility.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="icon" href="data:,">
+  </head>
+  <body>
+    <button id="submit" aria-describedby="hint" aria-required="true">Send form</button>
+    <p id="hint">Sends the form to the server</p>
+    <div id="hidden" aria-hidden="true">Invisible</div>
+    <input id="volume" type="range" min="0" max="10" value="7" aria-label="Volume">
+    <div id="scope">
+      <button>Inside only</button>
+    </div>
+    <button>Outside only</button>
+  </body>
+</html>

--- a/spec/support/views/accessibility_iframe.erb
+++ b/spec/support/views/accessibility_iframe.erb
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head><link rel="icon" href="data:,"></head>
+  <body>
+    <iframe src="/accessibility_iframe_child"></iframe>
+  </body>
+</html>

--- a/spec/support/views/accessibility_iframe_child.erb
+++ b/spec/support/views/accessibility_iframe_child.erb
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head><link rel="icon" href="data:,"></head>
+  <body>
+    <button id="child_btn" aria-label="Frame button">Click</button>
+  </body>
+</html>

--- a/spec/unit/accessibility/ax_node_spec.rb
+++ b/spec/unit/accessibility/ax_node_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "ferrum/accessibility/ax_node"
+
+describe Ferrum::Accessibility::AXNode do
+  let(:params) do
+    {
+      "nodeId" => "7",
+      "ignored" => false,
+      "role" => { "type" => "role", "value" => "button" },
+      "name" => { "type" => "computedString", "value" => "Send form" },
+      "description" => { "type" => "computedString", "value" => "Sends the form" },
+      "value" => { "type" => "computedString", "value" => "Go" },
+      "properties" => [
+        { "name" => "focusable", "value" => { "type" => "booleanOrUndefined", "value" => true } },
+        { "name" => "required", "value" => { "type" => "booleanOrUndefined", "value" => true } }
+      ],
+      "childIds" => %w[8 9],
+      "backendDOMNodeId" => 42
+    }
+  end
+
+  subject(:ax_node) { described_class.new(params) }
+
+  it "exposes role, name, description and value" do
+    expect(ax_node.role).to eq("button")
+    expect(ax_node.name).to eq("Send form")
+    expect(ax_node.description).to eq("Sends the form")
+    expect(ax_node.value).to eq("Go")
+  end
+
+  it "flattens properties into a name => value hash" do
+    expect(ax_node.properties).to eq("focusable" => true, "required" => true)
+  end
+
+  it "exposes identity and tree fields" do
+    expect(ax_node.node_id).to eq("7")
+    expect(ax_node.backend_dom_node_id).to eq(42)
+    expect(ax_node.child_ids).to eq(%w[8 9])
+    expect(ax_node.ignored?).to be(false)
+    expect(ax_node.to_h).to eq(params)
+  end
+
+  it "tolerates missing keys" do
+    node = described_class.new({ "nodeId" => "1", "ignored" => true })
+    expect(node.role).to be_nil
+    expect(node.name).to be_nil
+    expect(node.description).to be_nil
+    expect(node.value).to be_nil
+    expect(node.properties).to eq({})
+    expect(node.ignored?).to be(true)
+    expect(node.ignored_reasons).to be_nil
+  end
+
+  describe "immutability (deep freeze)" do
+    let(:mutable_params) do
+      {
+        "nodeId" => "10",
+        "ignored" => false,
+        "role" => { "type" => "role", "value" => "slider" },
+        "childIds" => %w[11 12],
+        "properties" => [
+          { "name" => "focusable", "value" => { "type" => "booleanOrUndefined", "value" => true } }
+        ]
+      }
+    end
+
+    subject(:frozen_node) { described_class.new(mutable_params) }
+
+    it "raises FrozenError when mutating child_ids" do
+      expect { frozen_node.child_ids << "x" }.to raise_error(FrozenError)
+    end
+
+    it "raises FrozenError when mutating the properties array from to_h" do
+      expect { frozen_node.to_h["properties"] << {} }.to raise_error(FrozenError)
+    end
+
+    it "freezes hash keys, not just values" do
+      key = frozen_node.to_h.keys.find { |k| k == "nodeId" }
+      expect(key).not_to be_nil
+      expect(key).to be_frozen
+    end
+
+    it "raises FrozenError when mutating the memoized properties hash" do
+      expect { frozen_node.properties["focusable"] = false }.to raise_error(FrozenError)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Reading an element's computed accessibility properties (role, name, description, ARIA state) under Ferrum means reaching past the public API into raw CDP:

```ruby
page.command("Accessibility.getPartialAXTree",
  nodeId: node.node_id, fetchRelatives: false)["nodes"]
```

This leaks the CDP wire shape into callers, is undiscoverable, and leaves no home for the rest of the Accessibility domain.

## Fix

Add a first-class `page.accessibility` domain object, mirroring `Ferrum::Network`:

- `node_for`, `partial_tree`, `snapshot`, `query`, `root`, `enable`/`disable`. Node-scoped commands run on the node's own page, so they resolve correctly across same-process iframes.
- `Ferrum::Accessibility::AXNode` value object wraps a CDP AXNode: `role`, `name`, `description`, `value`, `properties`, `ignored?`, `ignored_reasons`, `node_id`, `backend_dom_node_id`, `child_ids`, `to_h`. Params are deep-frozen; `value` is `untyped` since CDP `AXValue.value` may be a string, number, or boolean.
- `Ferrum::Node#axnode` convenience, mirroring `#computed_style`.

Query commands work without `Accessibility.enable` (that governs live events only); `enable`/`disable` are thin wrappers. `root` uses `getFullAXTree(depth: 1)` and `query` falls back to the document root node id, because CDP `getRootAXNode`/`queryAXTree` require those respectively.

## Testing

RBS signatures plus unit and browser-driven specs, including subtree-scoping proof and same-process iframe coverage for `node_for`, `partial_tree`, and `query`. CHANGELOG updated.


## Downstream validation

🤖 Validated against a real consumer: [`capybara_accessible_selectors#157`](https://github.com/citizensadvice/capybara_accessible_selectors/pull/157) (Cuprite driver support) resolves computed `name`/`role`/`description` from the accessibility tree.

Swapping its hand-rolled `Accessibility.getPartialAXTree` + ignored-node filtering + hash-digging for `node.axnode&.name` / `.role` / `.description` removed the raw-CDP coupling entirely. Full suite green on Cuprite — **1813 examples, 0 failures**.

Before:

```ruby
nodes = node.page.command("Accessibility.getPartialAXTree",
                          nodeId: node.node_id, fetchRelatives: false)["nodes"]
Array(nodes).find { |n| n["ignored"] == false }&.dig("name", "value")
```

After:

```ruby
node.axnode&.name
```
