### PR TITLE
fix: Text nodes are not what they seem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ### Added
 
+
 ### Changed
 
 ### Fixed
 - Full-page screenshots no longer resize the window, preventing focus steal on macOS [#580]
+- DOM.enable is now has `includeWhitespace: "all"` to keep track of new line nodes which previously were resolved to 0, and errored with NodeNotFoundError [#596]
+- `DOM.requestNode` call is moved to the node class and being done lazily, this reduces number of intermediate node ids sent by backend to frontend [#596]
 
 ### Removed
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "rspec", "~> 3.8"
 gem "rspec-wait"
 gem "rubocop", "~> 1.22"
 gem "rubocop-rake", require: false
-gem "sinatra", "~> 3.2"
+gem "sinatra", "~> 4.0"
 gem "yard", "~> 0.9", require: false
 
 gemspec

--- a/lib/ferrum/frame/runtime.rb
+++ b/lib/ferrum/frame/runtime.rb
@@ -152,13 +152,8 @@ module Ferrum
 
           case response["subtype"]
           when "node"
-            # We cannot store object_id in the node because page can be reloaded
-            # and node destroyed so we need to retrieve it each time for given id.
-            # Though we can try to subscribe to `DOM.childNodeRemoved` and
-            # `DOM.childNodeInserted` in the future.
-            node_id = @page.command("DOM.requestNode", objectId: object_id)["nodeId"]
-            description = @page.command("DOM.describeNode", nodeId: node_id)["node"]
-            Node.new(self, @page.target_id, node_id, description)
+            description = @page.command("DOM.describeNode", objectId: object_id)["node"]
+            Node.new(self, @page.target_id, description, object_id: object_id)
           when "array"
             reduce_props(object_id, []) do |memo, key, value|
               next(memo) unless Integer(key, exception: false)

--- a/lib/ferrum/node.rb
+++ b/lib/ferrum/node.rb
@@ -5,14 +5,29 @@ module Ferrum
     MOVING_WAIT_DELAY = ENV.fetch("FERRUM_NODE_MOVING_WAIT", 0.01).to_f
     MOVING_WAIT_ATTEMPTS = ENV.fetch("FERRUM_NODE_MOVING_ATTEMPTS", 50).to_i
 
-    attr_reader :page, :target_id, :node_id, :description, :tag_name
+    attr_reader :page, :target_id, :description, :tag_name
 
-    def initialize(frame, target_id, node_id, description)
+    def initialize(frame, target_id, description, object_id: nil, node_id: nil)
       @page = frame.page
       @target_id = target_id
-      @node_id = node_id
       @description = description
       @tag_name = description["nodeName"].downcase
+      @object_id = object_id
+      @node_id = node_id
+    end
+
+    # Frontend node id is resolved lazily, on first actual need (focus, click, scroll_into_view, etc.)
+    # We can try to subscribe to `DOM.childNodeRemoved` and `DOM.childNodeInserted` in the future
+    # to keep track of nodes.
+    def node_id
+      @node_id ||= begin
+        id = page.command("DOM.requestNode", objectId: @object_id)["nodeId"]
+        raise NodeNotFoundError, "node is not trackable" if id.zero?
+
+        id
+      rescue NoExecutionContextError
+        raise NodeNotFoundError, "node is not trackable"
+      end
     end
 
     def node?

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -459,7 +459,7 @@ module Ferrum
     def prepare_page
       command("Page.enable")
       command("Runtime.enable")
-      command("DOM.enable")
+      command("DOM.enable", includeWhitespace: "all")
       command("CSS.enable")
       command("Log.enable")
       command("Network.enable")

--- a/sig/ferrum/node.rbs
+++ b/sig/ferrum/node.rbs
@@ -4,11 +4,12 @@ module Ferrum
 
     MOVING_WAIT_ATTEMPTS: untyped
 
+    @node_id: untyped
+    @object_id: untyped
+
     attr_reader page: untyped
 
     attr_reader target_id: untyped
-
-    attr_reader node_id: untyped
 
     attr_reader description: untyped
 
@@ -25,6 +26,8 @@ module Ferrum
     def focus: () -> untyped
 
     def focusable?: () -> untyped
+
+    def node_id: -> untyped
 
     def wait_for_stop_moving: (?delay: untyped, ?attempts: untyped) -> untyped
 

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -148,6 +148,15 @@ describe Ferrum::Node do
       expect(links.size).to eq(1)
       expect(links.first.text).to eq("Open for match")
     end
+
+    it "works with whitespace nodes" do
+      browser.go_to("/ws_node")
+
+      values = browser.xpath("//li//text()").map(&:text)
+
+      expect(values.size).to eq(5)
+      expect(values).to eq(["\n        ", "\n          ", "b", "\n        ", "\n      "])
+    end
   end
 
   describe "#at_css" do
@@ -853,6 +862,17 @@ describe Ferrum::Node do
       browser.execute "window.location = 'about:blank'"
 
       expect { node.text }.to raise_error(Ferrum::NodeNotFoundError)
+    end
+
+    it "works for a new node after refresh" do
+      browser.go_to("/index")
+      shallow_node = browser.at_xpath(".//a")
+
+      browser.refresh
+      expect { shallow_node.click }.to raise_error(Ferrum::NodeNotFoundError)
+
+      node = browser.at_xpath(".//a")
+      expect { node.click }.not_to raise_error(Ferrum::NodeNotFoundError)
     end
   end
 end

--- a/spec/support/views/ws_node.erb
+++ b/spec/support/views/ws_node.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <body>
+    <ul>
+      <li>
+        <div>
+          <span>b</span>
+        </div>
+      </li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
Send all nodes from backend to frontend including hidden whitespace nodes which resolve to node id 0 without this setting on

https://github.com/rubycdp/ferrum/discussions/594