### PR TITLE
fix: trigger select-all via CDP commands field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - `Ferrum::Frame#lifecycle_events` provides a list of frame's events like init, networkIdle, firstPaint, etc. [#583]
 - `Ferrum::Frame#idle?` whether frame was loaded [#583]
 
+### Fixed
+- `Ferrum::Node#type` / `Ferrum::Keyboard` now trigger the select-all editing shortcut (`Ctrl`/`Cmd`+`A`) by naming the CDP `commands` field, so selecting and replacing text in inputs and contenteditables works.
+
 ### Changed
 - `Ferrum::PendingConnectionsError` and `Ferrum::TimeoutError` were swallowed even though happening when traffic iterator results in empty array. [#583]
 

--- a/lib/ferrum/keyboard.rb
+++ b/lib/ferrum/keyboard.rb
@@ -136,6 +136,13 @@ module Ferrum
               modifiers: pressed.map { |k| MODIFIERS[k] }.reduce(0, :|)
             )
 
+            # Synthetic key events alone do not trigger the browser's editing
+            # shortcuts (e.g. select-all). When the chord matches a platform
+            # accelerator, name the editing command explicitly so Chrome
+            # executes it via the CDP `commands` field.
+            command = editing_command(pressed, char)
+            key = key.merge(commands: [command]) if command
+
             modifiers = pressed.map { |k| to_options(KEYS.fetch(KEYS_MAPPING[k.to_sym])) }
             modifiers + [to_options(key)]
           end.flatten
@@ -156,6 +163,18 @@ module Ferrum
 
     def to_options(hash)
       hash.inject({}) { |memo, (k, v)| memo.merge(k.to_sym => v) }
+    end
+
+    # Names the CDP editing command for a modifier chord, or nil if the chord
+    # is not an editing accelerator. The accelerator modifier is Cmd on macOS
+    # and Ctrl elsewhere, matching Chrome's own key bindings. Currently only
+    # select-all is mapped; extend the guard for further commands as needed.
+    def editing_command(pressed, char)
+      return unless char.casecmp?("a")
+      return if pressed.include?("shift")
+
+      accelerator = Utils::Platform.mac? ? MODIFIERS["meta"] : MODIFIERS["ctrl"]
+      "selectAll" if pressed.map { |k| MODIFIERS[k] }.compact.uniq == [accelerator]
     end
   end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -516,6 +516,15 @@ describe Ferrum::Node do
         expect(input.value).to eq("Text appended")
       end
 
+      it "selects all in an input with the command modifier then clears" do
+        input = browser.at_css("#filled_input")
+        modifier = Ferrum::Utils::Platform.mac? ? :meta : :ctrl
+
+        input.focus.type([modifier, "a"], :backspace)
+
+        expect(input.value).to eq("")
+      end
+
       it "sends keys to empty textarea" do
         input = browser.at_css("#empty_textarea")
 
@@ -641,6 +650,15 @@ describe Ferrum::Node do
         input.click.type(" appended")
 
         expect(input.text).to eq("Content appended")
+      end
+
+      it "selects all with the command modifier then clears" do
+        input = browser.at_css("#filled_div")
+        modifier = Ferrum::Utils::Platform.mac? ? :meta : :ctrl
+
+        input.focus.type([modifier, "a"], :backspace)
+
+        expect(input.text).to eq("")
       end
 
       it "sets content" do


### PR DESCRIPTION
## Problem

`Ctrl`/`Cmd`+`A` does not select text when driven through `Ferrum::Node#type` / `Ferrum::Keyboard`. Selecting-then-replacing content in an `<input>` or a `contenteditable` is impossible, so callers resort to workarounds. Ferrum's own specs sidestep it — the `delete_all` helper in `spec/node_spec.rb` selects via `Shift`+modifier+`Right` caret movement rather than `Ctrl`+`A`, which only works for single-word content.

## Root cause

Synthetic key events dispatched via `Input.dispatchKeyEvent` do not trigger the browser's editing accelerators. This holds regardless of `text` presence or `keyDown`/`rawKeyDown` type — verified by probing a live browser: no key-event variant of `Ctrl`/`Cmd`+`A` produces a selection.

The reliable mechanism is the CDP [`commands`](https://chromedevtools.github.io/devtools-protocol/tot/Input/#method-dispatchKeyEvent) field on the key event: passing `commands: ["selectAll"]` makes Chrome run the editing command. This is how Playwright and Puppeteer implement editing shortcuts.

## Fix

When a chord matches the platform select-all accelerator (`Cmd` on macOS, `Ctrl` elsewhere), name the editing command via `commands`. Existing `text`/`modifiers` handling is untouched — only an extra field is added for the matching chord, so normal typing and all existing modifier behaviour are unaffected.

The `editing_command` helper is scoped to select-all for now (the common need) and excludes `Shift`, but is written to extend to further commands.

## Testing

New `#type` specs in `spec/node_spec.rb` cover a `contenteditable` (`#filled_div`) and an `<input>` (`#filled_input`): `type([mod, "a"], :backspace)` clears the field. The full `#type` context stays green (44 examples).

## Real-world beneficiaries

- [capybara_accessible_selectors](https://github.com/citizensadvice/capybara_accessible_selectors) — clearing a rich-text `contenteditable` currently needs a driver-specific backspace loop.
- [OpenProject's Capybara helpers](https://github.com/opf/openproject/blob/dev/spec/support/shared/cuprite_helpers.rb#L66) — `clear_input_field_contents` does a manual right+backspace dance on inputs (commented "Ferrum is yet support `fill_options`…"); collapses to `node.type([:control, "a"], :backspace)` once the accelerator works.
