### PR TITLE
Log websocket responses before delivering messages

### DIFF
--- a/lib/ferrum/client/web_socket.rb
+++ b/lib/ferrum/client/web_socket.rb
@@ -51,12 +51,6 @@ module Ferrum
 
       def on_message(event)
         data = safely_parse_json(event.data)
-        # If we couldn't parse JSON data for some reason (parse error or deeply nested object) we
-        # don't push response to @messages. Worse that could happen we raise timeout error due to command didn't return
-        # anything or skip the background notification, but at least we don't crash the thread that crashes the main
-        # thread and the application.
-        @messages.push(data) if data
-
         output = event.data
         if SKIP_LOGGING_SCREENSHOTS && @screenshot_commands[data&.dig("id")]
           @screenshot_commands.delete(data&.dig("id"))
@@ -64,6 +58,12 @@ module Ferrum
         end
 
         @logger&.puts("    ◀ #{Utils::ElapsedTime.elapsed_time} #{output}\n")
+
+        # If we couldn't parse JSON data for some reason (parse error or deeply nested object) we
+        # don't push response to @messages. Worse that could happen we raise timeout error due to command didn't return
+        # anything or skip the background notification, but at least we don't crash the thread that crashes the main
+        # thread and the application.
+        @messages.push(data) if data
       end
 
       def on_close(_event)


### PR DESCRIPTION
## Summary

- Log websocket responses before delivering them to waiting commands
- Prevent callers from reading logger output before the command response has been written

## Verification
- `bundle exec rspec spec/unit/browser_spec.rb`
- `bundle exec rspec spec/browser_spec.rb:44`
- `bundle exec rubocop lib/ferrum/client/web_socket.rb spec/unit/browser_spec.rb`
- `bundle exec rake test`
