### PR TITLE
Fix string matching for intercepted request URL patterns

### DIFF
--- a/lib/ferrum/network/intercepted_request.rb
+++ b/lib/ferrum/network/intercepted_request.rb
@@ -29,8 +29,13 @@ module Ferrum
         @params["isNavigationRequest"]
       end
 
-      def match?(regexp)
-        !!url.match(regexp)
+      def match?(pattern)
+        case url
+        when pattern
+          true
+        else
+          false
+        end
       end
 
       def respond(**options)

--- a/spec/network/intercepted_request_spec.rb
+++ b/spec/network/intercepted_request_spec.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
 describe Ferrum::Network::InterceptedRequest do
-  skip
+  subject(:request) { described_class.new(nil, params) }
+
+  let(:url) { "https://example.com/img/pattern.svg?1" }
+  let(:params) do
+    {
+      "requestId" => "interception-id",
+      "request" => { "url" => url }
+    }
+  end
+
+  describe "#match?" do
+    it "matches regular expressions" do
+      expect(request.match?(/pattern\.svg\?\d/)).to be(true)
+    end
+
+    it "matches exact strings" do
+      expect(request.match?("https://example.com/img/pattern.svg?1")).to be(true)
+    end
+
+    it "does not treat string patterns as regular expressions" do
+      expect(request.match?("pattern.svg?1")).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
  ## Summary

  - Fix `Ferrum::Network::InterceptedRequest#match?` so string patterns match URLs literally
  - Preserve regular expression matching for existing blacklist, whitelist, and request interception usage
  - Add regression coverage for URL strings containing regex metacharacters

  Closes #405.

  ## Verification

  - `bundle exec rspec spec/network/intercepted_request_spec.rb`
  - `bundle exec rspec spec/network/intercepted_request_spec.rb spec/network_spec.rb`
  - `bundle exec rubocop lib/ferrum/network/intercepted_request.rb spec/network/intercepted_request_spec.rb`
