### PR TITLE
Include console type and stack trace in logger output

### DIFF
--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -436,7 +436,7 @@ module Ferrum
 
       if @options.logger
         on("Runtime.consoleAPICalled") do |params|
-          params["args"].each { |r| @options.logger.puts(r["value"]) }
+          log_console_api(params)
         end
       end
 
@@ -491,6 +491,16 @@ module Ferrum
       # the history and if the transitionType for example `link` then
       # content is already loaded, and we can try to get the document.
       document_node_id
+    end
+
+    def log_console_api(params)
+      message = params.fetch("args", []).filter_map { |arg| arg["value"] || arg["description"] }.join(" ")
+      @options.logger.puts("[#{params['type']}] #{message}")
+
+      params.dig("stackTrace", "callFrames")&.each do |frame|
+        location = "#{frame['url']}:#{frame['lineNumber'].to_i + 1}:#{frame['columnNumber'].to_i + 1}"
+        @options.logger.puts("    at #{frame['functionName']} (#{location})")
+      end
     end
 
     def inject_extensions

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -45,6 +45,9 @@ describe Ferrum::Browser do
       browser = Ferrum::Browser.new(logger: logger)
       browser.go_to(base_url("/console_log"))
       expect(logger.string).to include("Hello world")
+      expect(logger.string).to include("[log] Hello world")
+      expect(logger.string).to include("at window.onload")
+      expect(logger.string).to include("/console_log")
     ensure
       browser&.quit
     end


### PR DESCRIPTION
## Summary

- Include the console API type in logger output for `Runtime.consoleAPICalled`
- Include stack trace call frames when Chrome provides them
- Preserve existing logger behavior that includes console argument values

Closes #419.

## Verification

- `bundle exec rspec spec/browser_spec.rb:44`
- `bundle exec rubocop lib/ferrum/page.rb spec/browser_spec.rb`
- `bundle exec rspec spec/browser_spec.rb`
