### PR TITLE
Fix typo in Network::Request documentation

### DIFF
--- a/lib/ferrum/network/request.rb
+++ b/lib/ferrum/network/request.rb
@@ -33,7 +33,7 @@ module Ferrum
       end
 
       #
-      # The request resouce type.
+      # The request resource type.
       #
       # @return [String]
       #


### PR DESCRIPTION
  ## Summary

  Fixes a typo in the `Ferrum::Network::Request#type` documentation:

  - `resouce` → `resource`

  ## Testing

  Not run; documentation-only change.