### PR TITLE
Add --no-crashpad default flag to the Chrome options

### DIFF
--- a/lib/ferrum/browser/options/chrome.rb
+++ b/lib/ferrum/browser/options/chrome.rb
@@ -55,6 +55,7 @@ module Ferrum
           "metrics-recording-only" => nil,
           "mute-audio" => nil,
           "no-crash-upload" => nil,
+          "no-crashpad" => nil,
           "no-default-browser-check" => nil,
           "no-first-run" => nil,
           "no-startup-window" => nil,


### PR DESCRIPTION
With the current default options for Chrome, a crashpad process still exists in the process list:

```
/opt/google/chrome/chrome_crashpad_handler --monitor-self --monitor-self-annotation=ptype=crashpad-handler  ...
```

The `--no-crashpad` flag is required to completely disable this feature for Chrome browser.

Version: Google Chrome 151.0.7922.71 