### PR TITLE
fix: use backend node id for file inputs

### DIFF
--- a/lib/ferrum/node.rb
+++ b/lib/ferrum/node.rb
@@ -121,7 +121,12 @@ module Ferrum
     end
 
     def select_file(value)
-      page.command("DOM.setFileInputFiles", slowmoable: true, nodeId: node_id, files: Array(value))
+      page.command(
+        "DOM.setFileInputFiles",
+        slowmoable: true,
+        backendNodeId: description["backendNodeId"],
+        files: Array(value)
+      )
     end
 
     def at_xpath(selector)

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -861,6 +861,37 @@ describe Ferrum::Node do
     end
   end
 
+  describe "#select_file" do
+    it "selects a file" do
+      browser.go_to("/form")
+      input = browser.at_css("#form_image")
+
+      input.select_file(File.expand_path(__FILE__))
+
+      expect(input.value).to eq("C:\\fakepath\\node_spec.rb")
+    end
+
+    it "uses the backend node id for the file input" do
+      page = instance_double(Ferrum::Page)
+      frame = instance_double(Ferrum::Frame, page: page)
+      node = described_class.new(
+        frame,
+        "target-id",
+        { "nodeName" => "INPUT", "backendNodeId" => 42 },
+        node_id: 7
+      )
+
+      expect(page).to receive(:command).with(
+        "DOM.setFileInputFiles",
+        slowmoable: true,
+        backendNodeId: 42,
+        files: ["spec/tmp/upload.txt"]
+      )
+
+      node.select_file("spec/tmp/upload.txt")
+    end
+  end
+
   describe "#drag_to", skip: true do
     before { browser.go_to("/drag") }
 


### PR DESCRIPTION
## Summary

- identify file inputs with their stable `backendNodeId` when calling `DOM.setFileInputFiles`
- cover both the exact CDP command and a real Chrome file selection

Fixes #568

## Verification

- `bundle exec rspec spec/node_spec.rb --example '#select_file'` (2 examples)
- `bundle exec rake test` (556 examples; the two local Chrome/path failures reproduce on unchanged `main`)
- `bundle exec rubocop --parallel` (99 files)
- `bundle exec rake build`
- `git diff --check`
