### PR TITLE
fix: drop the no-op `--no-crashpad` default flag [#610]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
   the browser; a failed `IO.close` is raised to the caller.
 
 ### Fixed
+- `--no-crashpad`, added to the default Chrome flags in 0.18.0 to stop `chrome_crashpad_handler` from spawning, is
+  not a Chromium switch at all, so Chrome silently ignored it and two handler processes kept starting per browser.
+  Removed. There is no replacement: the only switch that does stop them, `--disable-crashpad-for-testing`, is meant
+  for Chromium's own test harness and breaks a normally launched browser — child processes die at startup with
+  `Crashing due to FD ownership violation` and the network service crash-loops, while the browser process itself
+  survives and answers CDP, so every navigation returns `net::ERR_ABORTED` against an `about:blank` document.
+  Reap the handlers with an init in the container instead (`docker run --init`, `init: true`, or tini); Chrome's
+  crashpad behaviour is now documented under "The crashpad handler" in the customization docs [#610]
 - `#evaluate`/`#evaluate_on`/etc. resolved an object/array result by making two CDP round trips
   (`Runtime.callFunctionOn` to check for a cyclic reference, then `Runtime.getProperties`) per nested
   object or array, recursively — even though the cyclic check already walks the *entire* reachable

--- a/docs/2-customization.md
+++ b/docs/2-customization.md
@@ -60,6 +60,78 @@ Ferrum::Browser.new(options)
     * `:save_path` (String) - Path to save attachments with [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) header.
     * `:env` (Hash) - Environment variables you'd like to pass through to the process
 
+## The crashpad handler
+
+Chrome starts two `chrome_crashpad_handler` processes per browser on Linux. Their only job is to collect and upload
+crash reports, which no automated browser has any use for, but **Ferrum does not disable them**, because there is no
+safe way to.
+
+Handlers Chrome starts on Linux:
+
+| Chrome | `--headless` | `--headless=new` | headful |
+|---|---|---|---|
+| 127 and older | 0 | 2 | 2 |
+| 128 and newer | 2 | 2 | 2 |
+
+New headless always starts them. What changed in 128 is what bare `--headless` *means*: before it, that selected old
+headless, a separate lightweight shell with no crash handler; from 128 on it selects new headless, which is full
+Chrome. Headful has always behaved like new headless.
+
+### No flag turns them off safely
+
+| Flag | What it does |
+|---|---|
+| `--disable-breakpad` | Stops crash *reporting*, not the handler process |
+| `--disable-crash-reporter` | Same |
+| `--no-crashpad` | Not a Chromium switch at all, so Chrome ignores it |
+| `--disable-crashpad-for-testing` | Real, and it does stop them — but it breaks the browser |
+
+:::danger
+Do not pass `--disable-crashpad-for-testing`. It is named `for-testing` because it is meant for Chromium's own test
+harness, where the process tree is fully controlled. In a normally launched browser, child processes die at startup
+with `Crashing due to FD ownership violation`, and the network service crash-loops.
+
+The failure is near-invisible: the browser process survives, so it starts normally and CDP answers every command.
+There is simply no network service behind it, so every navigation returns `net::ERR_ABORTED` and the document stays
+`about:blank`.
+:::
+
+Ferrum shipped `--no-crashpad` as a default from 0.18.0 in an attempt at this. It never did anything, and has been
+removed.
+
+### Operating system differences
+
+On macOS one handler starts rather than two, and it exits when the browser does, so nothing accumulates.
+
+It is also invisible to `pstree`, because it double-forks and reparents to launchd and is therefore never a
+descendant of the process that started Chrome. Look for it globally instead:
+
+```console
+$ ps -Ao pid=,ppid=,comm= | grep crashpad
+13270     1 .../Helpers/chrome_crashpad_handler
+```
+
+`ppid` is `1`, and the pid usually lands just after Chrome's own.
+
+### Why this matters most in Docker
+
+The handler is not a problem outside a container, and killing the browser is not what deals with it. The handler is
+independent of Chrome's process group, so the signal Ferrum sends during teardown never reaches it — and does not
+need to. The handler watches the browser and exits by itself once Chrome is gone. Verified by sending `TERM` and
+`KILL` to the process group, and `KILL` and `SIGUSR1` to the browser pid directly: in every case it terminated on its
+own within a second.
+
+What is left behind is an exit status. Because the handler double-forks away from Chrome, its parent is pid 1, and
+pid 1 is what reaps it — systemd or launchd, silently, so nothing is left over and no cleanup is needed.
+
+In a container your own process is usually pid 1, and it does not wait on children it never spawned. Nothing reaps
+the handlers, so every browser leaves two more `<defunct>` entries behind, and they are never reclaimed.
+**They accumulate, until the process table fills up.**
+
+Run the container with an init — `docker run --init`, `init: true` in Compose, or tini as the entrypoint. It is worth
+doing regardless, since every other process in the image has the same problem, and there is no flag that avoids the
+need for it.
+
 ## Examples
 
 ```ruby

--- a/lib/ferrum/browser/options/chrome.rb
+++ b/lib/ferrum/browser/options/chrome.rb
@@ -61,7 +61,6 @@ module Ferrum
           "metrics-recording-only" => nil,
           "mute-audio" => nil,
           "no-crash-upload" => nil,
-          "no-crashpad" => nil,
           "no-default-browser-check" => nil,
           "no-first-run" => nil,
           "no-startup-window" => nil,


### PR DESCRIPTION
`--no-crashpad`, added to the default flags in 0.18.0 to stop `chrome_crashpad_handler` from spawning, is not a Chromium switch. Chrome silently ignores switches it doesn't recognise, so two handler processes kept starting per browser. Confirmed by launching Chrome 127/128/152/154 with and without it: the handler count is identical either way.

Removed, with no replacement. The one switch that does work, `--disable-crashpad-for-testing`, cannot be a default: it is meant for Chromium's own test harness and breaks a normally launched browser. Child processes die at startup with `Crashing due to FD ownership violation` and the network service crash-loops, while the browser process itself survives and answers CDP — so it looks healthy while every navigation returns `net::ERR_ABORTED` against an `about:blank` document. Trying it as a default took 315 of 603 specs down on all five Ruby versions.

Documents Chrome's crashpad behaviour instead, under "The crashpad handler" in the customization docs: which flags do and don't stop the handler and why, that the handler is outside Chrome's process group and self-terminates when the browser dies, and that reaping its exit status is pid 1's job — so a container needs an init (`docker run --init`, `init: true`, tini) and there is no flag that avoids that.

Also covers the Chrome 128 boundary, where bare `--headless` switched from old headless (no crash handler) to new headless (two), which is when this started appearing at all; and macOS, where one handler starts, exits with the browser, and is invisible to `pstree` because it reparents to launchd.