### PR TITLE
fix: don't block indefinitely waiting on the browser inside a finalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   the browser; a failed `IO.close` is raised to the caller.
 
 ### Fixed
+- `Ferrum::Browser::Process::Killer.kill` waited on the browser's leader pid with a blocking, unbounded
+  `Process.wait` after escalating to `KILL`. That method is installed as an `ObjectSpace` finalizer, so it can run
+  while the interpreter is shutting down, where a blocking wait risks hanging the process instead of letting it
+  exit.
 - `--no-crashpad`, added to the default Chrome flags in 0.18.0 to stop `chrome_crashpad_handler` from spawning, is
   not a Chromium switch at all, so Chrome silently ignored it and two handler processes kept starting per browser.
   Removed. There is no replacement: the only switch that does stop them, `--disable-crashpad-for-testing`, is meant

--- a/lib/ferrum/browser/process/killer.rb
+++ b/lib/ferrum/browser/process/killer.rb
@@ -22,6 +22,7 @@ module Ferrum
 
         KILL_TIMEOUT = 2
         WAIT_KILLED = 0.05
+        REAP_TIMEOUT = 0.5
         REMOVE_DIR_RETRIES = 5
         REMOVE_DIR_RETRY_DELAY = 0.1
 
@@ -57,11 +58,38 @@ module Ferrum
             next unless Utils::ElapsedTime.timeout?(start, KILL_TIMEOUT)
 
             send_signal(pid, "KILL")
-            ::Process.wait(pid) unless leader_exited
+            wait_reaped(pid) unless leader_exited
             break
           end
         rescue Errno::ESRCH, Errno::ECHILD
           # nop
+        end
+
+        #
+        # Waits for `pid` to become reapable, giving up after `timeout`.
+        #
+        # Deliberately a bounded poll rather than a blocking `Process.wait`.
+        # {#process_killer} installs {#kill} as an `ObjectSpace` finalizer, so
+        # it can run while the interpreter is shutting down, and a blocking
+        # wait there never returns.
+        #
+        # @param [Integer] pid
+        # @param [Float] timeout
+        #
+        # @return [Integer, nil]
+        #   The reaped pid, or `nil` if it didn't exit in time or wasn't ours.
+        #
+        def wait_reaped(pid, timeout: REAP_TIMEOUT)
+          start = Utils::ElapsedTime.monotonic_time
+          loop do
+            reaped = ::Process.wait(pid, ::Process::WNOHANG)
+            return reaped if reaped
+            return nil if Utils::ElapsedTime.timeout?(start, timeout)
+
+            sleep(WAIT_KILLED)
+          end
+        rescue Errno::ECHILD, Errno::ESRCH
+          nil
         end
 
         #

--- a/sig/ferrum/browser/process/killer.rbs
+++ b/sig/ferrum/browser/process/killer.rbs
@@ -6,11 +6,15 @@ module Ferrum
 
         WAIT_KILLED: ::Float
 
+        REAP_TIMEOUT: ::Float
+
         REMOVE_DIR_RETRIES: ::Integer
 
         REMOVE_DIR_RETRY_DELAY: ::Float
 
         def self.kill: (::Integer pid) -> void
+
+        def self.wait_reaped: (::Integer pid, ?timeout: ::Float) -> ::Integer?
 
         def self.process_killer: (::Integer pid) -> Proc
 

--- a/spec/unit/process/killer_spec.rb
+++ b/spec/unit/process/killer_spec.rb
@@ -57,6 +57,32 @@ describe Ferrum::Browser::Process::Killer do
     end
   end
 
+  describe ".wait_reaped", if: Ferrum::Utils::Platform.mri? && !Ferrum::Utils::Platform.windows? do
+    it "returns the pid once the process has exited" do
+      pid = Process.spawn("true")
+
+      expect(described_class.wait_reaped(pid)).to eq(pid)
+    end
+
+    it "returns nil for a process that was never ours" do
+      expect(described_class.wait_reaped(1, timeout: 0.1)).to be_nil
+    end
+
+    # #kill is installed as an ObjectSpace finalizer, so it can run while the
+    # interpreter is shutting down. A blocking Process.wait there never
+    # returns and the process hangs instead of exiting -- cuprite#231.
+    it "gives up rather than blocking forever on a process that won't exit" do
+      pid = Process.spawn("sleep 30")
+      start = Ferrum::Utils::ElapsedTime.monotonic_time
+
+      expect(described_class.wait_reaped(pid, timeout: 0.2)).to be_nil
+      expect(Ferrum::Utils::ElapsedTime.monotonic_time - start).to be < 5
+    ensure
+      Process.kill("KILL", pid)
+      Process.wait(pid)
+    end
+  end
+
   describe ".process_group_alive?", if: Ferrum::Utils::Platform.mri? do
     it "returns true while the process group has a live member" do
       pid = Process.spawn("sleep 30", pgroup: true)


### PR DESCRIPTION
`Killer.kill` escalated to `KILL` and then called a blocking, unbounded `Process.wait(pid)`. `Killer.process_killer` installs that same method as an `ObjectSpace` finalizer, so it can run while the interpreter is shutting down, where a blocking wait risks hanging the process instead of letting it exit.

Reported in cuprite#231 for Rails parallel system tests: a forked worker never exits, so the parent loops forever waiting to collect it and CI hangs with every test passing. Confirmed there by reading `/proc/PID/wchan` (`do_wait`) on the stuck parent.

Replaced with `wait_reaped`, a bounded poll that gives up after `REAP_TIMEOUT` and returns nil rather than blocking.

This is hardening, not a reproduced fix, and the scope is narrow. The blocking call is only reachable when the leader survives `TERM` for the full `KILL_TIMEOUT`: a well-behaved leader takes 0.06s and never reaches it, a `TERM`-ignoring one takes 2.08s and does. Chrome dies on `TERM`, so an ordinary `#quit` never touched it.

Attempts to reproduce the hang failed on both platforms. Forked workers that leak a browser and exit without `#quit` complete in ~1.3s either way, since the path is never entered. Forcing entry — a leader wedged against `TERM`, killed from a finalizer at interpreter shutdown, verified on Linux to reach the blocking call — still completed in ~2.05s with and without the change, because `KILL` lands and the wait returns. Whatever produces the reported hang needs a condition these tests do not capture.

The specs pin the new helper's contract; they do not reproduce the hang. Kept regardless because an unbounded blocking wait inside a finalizer is the wrong shape whether or not this particular report is explained by it.