### PR TITLE
ci: cap test job runtime with timeout-minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         ruby: ["3.1", "3.2", "3.3", "3.4", "4.0"]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       FERRUM_PROCESS_TIMEOUT: 25
       FERRUM_DEFAULT_TIMEOUT: 15
@@ -33,6 +34,7 @@ jobs:
           chrome-version: stable
 
       - name: Run tests
+        timeout-minutes: 15
         run: |
           mkdir -p /tmp/ferrum
           bundle exec rake


### PR DESCRIPTION
`.github/workflows/tests.yml` has no `timeout-minutes`, so a wedged browser keeps the job alive until GitHub's 6-hour default cap — burning runner minutes and delaying feedback on every other job in the matrix.

- `timeout-minutes: 20` on the `tests` job as the hard backstop.
- `timeout-minutes: 15` on the `Run tests` step so it fires first: the step fails, and `Archive artifacts` still runs and uploads `/tmp/ferrum`. A job-level timeout alone kills the runner before that step, losing the evidence of what hung.