### PR TITLE
fix: resume and detach from targets we don't track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   the browser; a failed `IO.close` is raised to the caller.
 
 ### Fixed
+- Targets of a type `Ferrum::Contexts` doesn't track were left attached and paused by auto-attach for the lifetime
+  of the browser; Chrome opens two `browser_ui` ones per browser context. They're now resumed and detached from
 - `Ferrum::Browser::Process::Killer.kill` waited on the browser's leader pid with a blocking, unbounded
   `Process.wait` after escalating to `KILL`. That method is installed as an `ObjectSpace` finalizer, so it can run
   while the interpreter is shutting down, where a blocking wait risks hanging the process instead of letting it

--- a/lib/ferrum/contexts.rb
+++ b/lib/ferrum/contexts.rb
@@ -135,7 +135,7 @@ module Ferrum
     def subscribe_attached_target(client)
       client.on("Target.attachedToTarget") do |params|
         info, session_id = params.values_at("targetInfo", "sessionId")
-        next unless ALLOWED_TARGET_TYPES.include?(info["type"])
+        next detach_untracked(session_id) unless ALLOWED_TARGET_TYPES.include?(info["type"])
 
         context_id = info["browserContextId"]
         add_context(context_id)
@@ -199,6 +199,16 @@ module Ferrum
       elsif params["waitingForDebugger"]
         resume(session_id)
       end
+    end
+
+    # Auto-attach pauses every target it attaches to, including the types
+    # we don't track: Chrome's own `browser_ui` targets, for instance. We
+    # never resume those, so left alone they stay attached and paused for
+    # the lifetime of the browser. Resume them and drop the session.
+    def detach_untracked(session_id)
+      detach(session_id)
+    rescue BrowserError, TimeoutError
+      nil
     end
 
     # Attaching keeps a service worker alive forever, so unless the caller

--- a/sig/ferrum/contexts.rbs
+++ b/sig/ferrum/contexts.rbs
@@ -47,6 +47,8 @@ module Ferrum
 
     def handle_attach: (Target? target, String session_id, Hash[String, untyped] params) -> void
 
+    def detach_untracked: (String session_id) -> void
+
     def detach_unless_manually_attached: (Target target, String session_id) -> void
 
     def connect_worker: (Target target) -> void

--- a/spec/contexts_spec.rb
+++ b/spec/contexts_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+describe Ferrum::Contexts do
+  # Chrome opens two `chrome://omnibox-popup.top-chrome/` (`browser_ui`) targets per
+  # browser context. Auto-attach runs with `waitForDebuggerOnStart`, so they arrive
+  # paused, and nothing resumes a type we don't track: left alone they stay attached
+  # and paused for the lifetime of the browser.
+  it "detaches from attached targets of a type it doesn't track" do
+    untracked = Concurrent::Array.new
+    detached = Concurrent::Array.new
+
+    attached_id = browser.client.on("Target.attachedToTarget") do |params|
+      type = params["targetInfo"]["type"]
+      untracked << params["sessionId"] unless described_class::ALLOWED_TARGET_TYPES.include?(type)
+    end
+    detached_id = browser.client.on("Target.detachedFromTarget") { |params| detached << params["sessionId"] }
+
+    browser.contexts.create.create_page
+
+    wait(5).for { untracked.size }.to be >= 2
+    wait(5).for { untracked - detached }.to be_empty
+  ensure
+    browser.client.off("Target.attachedToTarget", attached_id)
+    browser.client.off("Target.detachedFromTarget", detached_id)
+  end
+end


### PR DESCRIPTION
`Contexts::ALLOWED_TARGET_TYPES` excludes `browser_ui`, but auto-attach is armed with `waitForDebuggerOnStart: true`. Every target Chrome attaches starts paused.

Chrome 152 opens two `chrome://omnibox-popup.top-chrome/` (`browser_ui`) targets per browser context, so a plain `Ferrum::Browser.new` leaks two sessions and each extra context adds two more.

Untracked targets now go through `detach_untracked`, which resumes the debugger and drops the session — the same treatment service workers already get.