### PR TITLE
fix: kill the browser before removing its user data directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   the browser; a failed `IO.close` is raised to the caller.
 
 ### Fixed
+- `Ferrum::Browser::Process` registered two `ObjectSpace` finalizers on the same object, a directory remover and
+  a process killer. Ruby runs them FIFO so directory could have been deleted before process dead, and browser could
+  have restored its content on exit.
 - `Ferrum::Browser::Process::Killer.kill` waited on the browser's leader pid with a blocking, unbounded
   `Process.wait` after escalating to `KILL`. That method is installed as an `ObjectSpace` finalizer, so it can run
   while the interpreter is shutting down, where a blocking wait risks hanging the process instead of letting it

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -59,10 +59,8 @@ module Ferrum
         @process_timeout = options.process_timeout
         @env = Hash(options.env)
 
-        tmpdir = Dir.mktmpdir("ferrum_user_data_dir_")
-        ObjectSpace.define_finalizer(self, Killer.directory_remover(tmpdir))
-        @user_data_dir = tmpdir
-        @command = Command.build(options, tmpdir)
+        @user_data_dir = Dir.mktmpdir("ferrum_user_data_dir_")
+        @command = Command.build(options, @user_data_dir)
       end
 
       #
@@ -80,14 +78,11 @@ module Ferrum
           process_options[:pgroup] = true unless Utils::Platform.windows?
           process_options[:out] = process_options[:err] = write_io
 
-          if @command.xvfb?
-            @xvfb = Xvfb.start(@command.options)
-            ObjectSpace.define_finalizer(self, Killer.process_killer(@xvfb.pid))
-          end
+          @xvfb = Xvfb.start(@command.options) if @command.xvfb?
 
           env = Hash(@xvfb&.to_env).merge(@env)
           @pid = ::Process.spawn(env, *@command.to_a, process_options)
-          ObjectSpace.define_finalizer(self, Killer.process_killer(@pid))
+          ObjectSpace.define_finalizer(self, Killer.finalizer([@pid, @xvfb&.pid], @user_data_dir))
 
           parse_ws_url(read_io, @process_timeout)
           parse_json_version(ws_url)

--- a/lib/ferrum/browser/process/killer.rb
+++ b/lib/ferrum/browser/process/killer.rb
@@ -69,7 +69,7 @@ module Ferrum
         # Waits for `pid` to become reapable, giving up after `timeout`.
         #
         # Deliberately a bounded poll rather than a blocking `Process.wait`.
-        # {#process_killer} installs {#kill} as an `ObjectSpace` finalizer, so
+        # {#finalizer} installs {#kill} as an `ObjectSpace` finalizer, so
         # it can run while the interpreter is shutting down, and a blocking
         # wait there never returns.
         #
@@ -93,15 +93,28 @@ module Ferrum
         end
 
         #
-        # Builds a finalizer proc that kills the process with the given pid.
+        # Builds the proc registered as a browser's `ObjectSpace` finalizer,
+        # cleaning up after a browser nobody quit.
         #
-        # @param [Integer] pid
-        #   Process id to kill.
+        # Kills every pid first and removes the directory afterwards. That
+        # order is the whole point of this being one finalizer instead of
+        # two: Ruby runs an object's finalizers in registration order, and
+        # removing the user data directory while the browser is still alive
+        # means Chrome recreates it on the way out, leaking it for good.
+        #
+        # @param [Array<Integer>, Integer, nil] pids
+        #   Process ids to kill, e.g. the browser and Xvfb.
+        # @param [String, nil] path
+        #   User data directory to remove once they are dead.
         #
         # @return [Proc]
         #
-        def process_killer(pid)
-          proc { kill(pid) }
+        def finalizer(pids, path)
+          pids = Array(pids).compact
+          proc do
+            pids.each { |pid| kill(pid) }
+            remove_directory(path) if path
+          end
         end
 
         #
@@ -168,19 +181,6 @@ module Ferrum
           end
         rescue StandardError => e
           warn("[Ferrum] Failed to remove user data dir #{path}: #{e.class}: #{e.message}")
-        end
-
-        #
-        # Builds a finalizer proc that removes the directory at the given
-        # path.
-        #
-        # @param [String] path
-        #   Directory to remove.
-        #
-        # @return [Proc]
-        #
-        def directory_remover(path)
-          proc { remove_directory(path) }
         end
       end
     end

--- a/sig/ferrum/browser/process/killer.rbs
+++ b/sig/ferrum/browser/process/killer.rbs
@@ -16,15 +16,13 @@ module Ferrum
 
         def self.wait_reaped: (::Integer pid, ?timeout: ::Float) -> ::Integer?
 
-        def self.process_killer: (::Integer pid) -> Proc
+        def self.finalizer: (Array[::Integer] | ::Integer | nil pids, ::String? path) -> Proc
 
         def self.send_signal: (::Integer pid, ::String name) -> void
 
         def self.process_group_alive?: (::Integer pid) -> bool
 
         def self.remove_directory: (::String path, ?retries: ::Integer, ?delay: ::Float) -> void
-
-        def self.directory_remover: (::String path) -> Proc
       end
     end
   end

--- a/spec/unit/process/killer_spec.rb
+++ b/spec/unit/process/killer_spec.rb
@@ -83,6 +83,63 @@ describe Ferrum::Browser::Process::Killer do
     end
   end
 
+  describe ".finalizer", if: Ferrum::Utils::Platform.mri? && !Ferrum::Utils::Platform.windows? do
+    def reaped?(pid)
+      Process.waitpid(pid, Process::WNOHANG)
+      false
+    rescue Errno::ECHILD
+      true
+    end
+
+    it "kills the process before removing its directory" do
+      dir = Dir.mktmpdir
+      # Stands in for Chrome, which writes to its profile on the way out: a
+      # directory removed while it is still alive comes straight back.
+      pid = Process.spawn(RbConfig.ruby, "-e", <<~RUBY, dir, pgroup: true)
+        require "fileutils"
+        trap("TERM") do
+          FileUtils.mkdir_p(ARGV[0])
+          File.write(File.join(ARGV[0], "lock"), "x")
+          exit!
+        end
+        FileUtils.mkdir_p(ARGV[0])
+        File.write(File.join(ARGV[0], "lock"), "x")
+        loop { sleep 0.05 }
+      RUBY
+      start = Ferrum::Utils::ElapsedTime.monotonic_time
+      sleep(0.02) until File.exist?(File.join(dir, "lock")) ||
+                        Ferrum::Utils::ElapsedTime.timeout?(start, 5)
+
+      described_class.finalizer(pid, dir).call
+      sleep(0.2)
+
+      expect(Dir.exist?(dir)).to be false
+    ensure
+      begin
+        Process.kill("KILL", pid) if pid
+      rescue Errno::ESRCH
+        nil
+      end
+      FileUtils.remove_entry(dir) if Dir.exist?(dir.to_s)
+    end
+
+    it "kills every pid it was given" do
+      pids = Array.new(2) { Process.spawn("sleep 30", pgroup: true) }
+
+      described_class.finalizer(pids, nil).call
+
+      expect(pids.map { |pid| reaped?(pid) }).to all(be true)
+    end
+
+    it "removes the directory when there is nothing to kill" do
+      dir = Dir.mktmpdir
+
+      described_class.finalizer(nil, dir).call
+
+      expect(Dir.exist?(dir)).to be false
+    end
+  end
+
   describe ".process_group_alive?", if: Ferrum::Utils::Platform.mri? do
     it "returns true while the process group has a live member" do
       pid = Process.spawn("sleep 30", pgroup: true)
@@ -100,28 +157,6 @@ describe Ferrum::Browser::Process::Killer do
       Process.wait(pid)
 
       expect(described_class.process_group_alive?(pid)).to be false
-    end
-  end
-
-  describe ".process_killer" do
-    it "builds a proc that kills the given pid when called", if: Ferrum::Utils::Platform.mri? do
-      pid = Process.spawn("sleep 30", pgroup: true)
-      expect(described_class).to receive(:kill).with(pid)
-
-      described_class.process_killer(pid).call
-    ensure
-      Process.kill("KILL", -pid)
-      Process.wait(pid)
-    end
-  end
-
-  describe ".directory_remover" do
-    it "builds a proc that removes the given directory when called" do
-      dir = Dir.mktmpdir
-
-      described_class.directory_remover(dir).call
-
-      expect(Dir.exist?(dir)).to be false
     end
   end
 end


### PR DESCRIPTION
`Ferrum::Browser::Process` registered two `ObjectSpace` finalizers on the same object: a directory remover in `#initialize`, and a process killer in `#start`. Ruby runs an object's finalizers in the order they were registered, so the directory went first.

That only bites when cleanup happens through the finalizer instead of an explicit `#quit` — which is exactly when the caller is relying on Ferrum to clean up. The profile is removed out from under a live Chrome, Chrome recreates it while shutting down, and the directory is leaked for good. The retries in `#remove_directory` cannot help: the removal succeeds, and the directory comes back afterwards.

Measured on macOS, three browsers created and left to the finalizer:

  before: 3 user-data-dirs leaked, 7 files each
  after:  0

`Killer.process_killer` and `Killer.directory_remover` are replaced by a single `Killer.finalizer(pids, path)`, registered once in `#start` now that both the pids and the directory are known there. Xvfb's pid goes into the same call rather than a finalizer of its own.

The regression test drives the ordering rather than relying on a race: the stand-in process recreates its own directory on TERM, the way Chrome writes to its profile on shutdown. Reverse the two lines and the example fails.

Note the explicit `#quit` path was always correct — `sync_stop` kills and then removes — so this only ever affected callers who never quit.