### PR TITLE
fix(downloads): don't address the browser's implicit context by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
   window (browserless). That window lives in the browser's implicit context, which Chrome below 145
   won't address by id. Ferrum now detects it and exposes as `Ferrum::Context#implicit?`. It's never
   disposed, so `#reset` won't clear such a browser. [#578] [#627]
+- `Browser.setDownloadBehavior` raised `Failed to find browser context for id` for a page in the browser's implicit
+  context, so connecting to a browser that came up with its own startup window and passing `:save_path` died on the
+  first page. `Ferrum::Target#context_id`, and with it `Ferrum::Page#context_id`, is now `nil` for that context,
+  which is how Chrome wants it addressed, by omitting `browserContextId` [#546]
 - Connecting to a remote browser with `:url` drops query string when probing `/json/version`, endpoint might answer
   401 and Ferrum died with `undefined method 'host' for nil`. in case of parse issues `Ferrum::NoWebSocketUrlError` is raised.
 - Targets of a type `Ferrum::Contexts` doesn't track were left attached and paused by auto-attach for the lifetime

--- a/lib/ferrum/context.rb
+++ b/lib/ferrum/context.rb
@@ -126,7 +126,7 @@ module Ferrum
     #
     # @return [Target]
     def add_target(params:, session_id: nil)
-      new_target = Target.new(@client, session_id, params)
+      new_target = Target.new(@client, session_id, params, implicit: implicit?)
       # `put_if_absent` returns nil if added a new value or existing if there was one already
       target = @targets.put_if_absent(new_target.id, new_target) || new_target
       # on first iteration session_id may be nil, then if session is present here we must set it to the target

--- a/lib/ferrum/downloads.rb
+++ b/lib/ferrum/downloads.rb
@@ -62,8 +62,9 @@ module Ferrum
       raise ArgumentError unless VALID_BEHAVIOR.include?(behavior.to_sym)
       raise Error, "supply absolute path for `:save_path` option" unless Pathname.new(save_path.to_s).absolute?
 
+      options = { browserContextId: @page.context_id } if @page.context_id
       @page.command("Browser.setDownloadBehavior",
-                    browserContextId: @page.context_id,
+                    **Hash(options),
                     downloadPath: save_path,
                     behavior: behavior,
                     eventsEnabled: true)

--- a/lib/ferrum/target.rb
+++ b/lib/ferrum/target.rb
@@ -17,11 +17,12 @@ module Ferrum
     attr_reader :options
     attr_accessor :session_id
 
-    def initialize(browser_client, session_id = nil, params = nil)
+    def initialize(browser_client, session_id = nil, params = nil, implicit: false)
       @page = nil
       @worker = nil
       @session_id = session_id
       @params = params
+      @implicit = implicit
       @browser_client = browser_client
       @options = browser_client.options
     end
@@ -137,11 +138,14 @@ module Ferrum
       @params["parentId"]
     end
 
-    # The id of the browser context this target belongs to.
+    # The id of the browser context this target belongs to, `nil` for the
+    # browser's implicit context, which Chrome doesn't let us address by id,
+    # see {Context#implicit?}. Commands scoped to a browser context target it
+    # by omitting `browserContextId`.
     #
     # @return [String, nil]
     def context_id
-      @params["browserContextId"]
+      @params["browserContextId"] unless @implicit
     end
 
     # Whether this target is a window/tab, i.e. was opened via

--- a/sig/ferrum/page.rbs
+++ b/sig/ferrum/page.rbs
@@ -12,7 +12,7 @@ module Ferrum
     include Interceptable
 
     attr_accessor referrer: String?
-    attr_reader context_id: String
+    attr_reader context_id: String?
     attr_reader target_id: String
     attr_reader event: Utils::Event
     attr_reader tracing: Page::Tracing
@@ -26,7 +26,7 @@ module Ferrum
     attr_reader client: (Client | SessionClient)
 
     @client: (Client | SessionClient)
-    @context_id: String
+    @context_id: String?
     @target_id: String
     @options: Browser::Options
     @frames: ::Concurrent::Map[String, Frame]
@@ -41,7 +41,7 @@ module Ferrum
     @downloads: Downloads
     @referrer: String?
 
-    def initialize: ((Client | SessionClient) client, context_id: String, target_id: String, ?proxy: { host: String, port: ::Integer, user: String?, password: String? }?) -> void
+    def initialize: ((Client | SessionClient) client, context_id: String?, target_id: String, ?proxy: { host: String, port: ::Integer, user: String?, password: String? }?) -> void
 
     def context: () -> Context?
 

--- a/sig/ferrum/target.rbs
+++ b/sig/ferrum/target.rbs
@@ -10,11 +10,12 @@ module Ferrum
     @worker: Worker?
     @session_id: String?
     @params: Hash[String, untyped]
+    @implicit: bool
     @browser_client: Client
     @options: Browser::Options
     @client: (Client | SessionClient)?
 
-    def initialize: (Client browser_client, ?String? session_id, ?Hash[String, untyped]? params) -> void
+    def initialize: (Client browser_client, ?String? session_id, ?Hash[String, untyped]? params, ?implicit: bool) -> void
 
     def update: (Hash[String, untyped] params) -> Hash[String, untyped]
 

--- a/spec/downloads_spec.rb
+++ b/spec/downloads_spec.rb
@@ -70,6 +70,24 @@ describe Ferrum::Downloads do
       end
     end
 
+    context "with the browser's implicit context" do
+      it "saves an attachment" do
+        with_external_browser(incognito: false) do |url|
+          remote = Ferrum::Browser.new(url: url, base_url: base_url, save_path: save_path)
+          remote_page = remote.create_page
+
+          expect(remote_page.context_id).to be_nil
+
+          remote_page.downloads.wait { remote_page.go_to("/#{filename}") }
+
+          expect(File.exist?("#{save_path}/#{filename}")).to be true
+        ensure
+          remote&.quit
+          FileUtils.rm_rf(save_path)
+        end
+      end
+    end
+
     context "with local path" do
       let(:save_path) { "spec/tmp" }
 


### PR DESCRIPTION
Closes #546.

## The bug

`Downloads#set_behavior` sent `browserContextId: @page.context_id` unconditionally. For a page in the browser's implicit context — the one Chrome puts its startup window in — that id isn't addressable, so the first page died with:

```
Ferrum::BrowserError: Failed to find browser context for id 97B71EC807EDF5868B937479FC2E4324
  lib/ferrum/client.rb:367 raise_browser_error
  lib/ferrum/page.rb:448   Ferrum::Page#command
```

It reproduces on `main` against any browser that came up with its own startup window (a Chrome in a sidecar container, browserless) when `:save_path` is set, since `prepare_page` configures the download behavior for every page. It is not flatten-specific — `flatten: false` fails identically — and not version-specific either, Chrome 152 fails the same way as the 119 in the report. Same root cause as #578/#627, which fixed it for `Target.createTarget` only.

## The fix

`Target#context_id`, and with it `Page#context_id`, is `nil` for the implicit context, so a caller scoping a command to a browser context can tell it apart from the id alone, without reaching for the context object:

```ruby
options = { browserContextId: @page.context_id } if @page.context_id
@page.command("Browser.setDownloadBehavior", **Hash(options), ...)
```

`Context#create_target` and `Contexts#dispose` keep the `implicit?` checks they already had, so all three CDP calls that take a `browserContextId` are covered. Those three are the only ones in the codebase — everything else is target- or session-scoped.

Two alternatives that don't work, both checked against a live browser:

- Always omitting `browserContextId`: downloads in a context we created come back `canceled`, the behavior lands on the default context instead.
- Setting the behavior once per context from the browser session: files save, but `Browser.downloadWillBegin`/`downloadProgress` are then delivered to the browser session and `page.downloads.files`/`#wait` track nothing. The command has to stay on the page's session.

Cuprite builds its own pages with `Page.new(target.client, context_id: target.context_id, ...)`, so it picks this up unchanged.

## Verification

- New spec in `spec/downloads_spec.rb`, using `with_external_browser(incognito: false)` for a browser with a startup window. It fails with `Failed to find browser context for id` without the fix.
- Full suite: 614 examples, 0 failures.
- Manually, against a startup-window Chrome in both flatten modes: the download completes, the file is saved and stays tracked on the page, while a context created by Ferrum in the same browser still saves to its own `save_path`.
- `rbs validate` passes. `Page#context_id` is `String?` now, since `Target` is what passes it and it can be nil.