### PR TITLE
fix(subscriber): don't let a raising callback kill event dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   the browser; a failed `IO.close` is raised to the caller.
 
 ### Fixed
+- A raising callback killed `Client::Subscriber`'s dispatch thread and with it every event for the rest of the
+  process: pages created later raised `NoSuchTargetError`, open ones lost their execution contexts. Callbacks are
+  now rescued one by one and reported to stderr [#470]
 - `create_page` raised `Failed to find browser context with id` against a browser that came up with its own startup
   window (browserless). That window lives in the browser's implicit context, which Chrome below 145
   won't address by id. Ferrum now detects it and exposes as `Ferrum::Context#implicit?`. It's never

--- a/lib/ferrum/client/subscriber.rb
+++ b/lib/ferrum/client/subscriber.rb
@@ -133,6 +133,11 @@ module Ferrum
         @on[event]&.each_with_index do |block, index|
           # In case of multiple callbacks we provide current index and total
           block.call(params, index, total)
+        rescue StandardError => e
+          # A raising callback used to terminate the dispatch thread, and with it every
+          # event for the rest of the browser's life: targets stopped being registered
+          # and any page created later raised `NoSuchTargetError`. Report and carry on.
+          warn("Ferrum: #{event} callback raised #{e.class}: #{e.message}\n  #{e.backtrace&.first}")
         end
       end
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe Ferrum::Client do
+  describe "event callbacks" do
+    let(:remote) { Ferrum::Browser.new(base_url: base_url, timeout: 3, protocol_timeout: 3) }
+
+    after { remote.quit }
+
+    it "keeps dispatching events when a callback raises" do
+      page = remote.create_page
+
+      expect do
+        remote.client.on("Target.targetCreated") { raise Ferrum::TimeoutError }
+
+        2.times { remote.create_page }
+        page.go_to("/")
+      end.to output(/Target.targetCreated callback raised Ferrum::TimeoutError/).to_stderr
+
+      expect(page.body).to include("Hello world!")
+    end
+  end
+end


### PR DESCRIPTION
Refs #470.

## The problem

`Client::Subscriber` dispatches every CDP event on a single thread, and the loop had no rescue:

```ruby
loop do
  message = @regular.pop
  break unless message
  call(message)          # a raising callback ends the thread, permanently
end
```

So the first exception out of any callback kills dispatch for the rest of the process. Every event after that is dropped: targets are never registered, pages created later raise `NoSuchTargetError`, and pages already open lose their execution contexts.

Reproduced on main:

```ruby
b = Ferrum::Browser.new(protocol_timeout: 3, timeout: 3)
page = b.create_page                                                # ok
b.client.on("Target.targetCreated") { raise Ferrum::TimeoutError }  # e.g. a CDP call inside a handler
b.create_page                                                       # ok
b.create_page                                                       # Ferrum::NoSuchTargetError
page.go_to("data:text/html,<h1>hi</h1>")                            # Ferrum::NoExecutionContextError
```

It prints `#<Thread:...utils/thread.rb...> terminated with exception (report_on_exception is true)` and from then on the connection is deaf. That is the exact failure sequence reported in #470: a `Ferrum::TimeoutError` raised inside a Ferrum thread, followed by every later test failing with `Ferrum::NoSuchTargetError` from `Context#create_target`.

Callbacks that issue CDP commands make this reachable on any slow or loaded machine: the default `on(:dialog)` handler accepting a dialog, network interception blocks, or a driver's own handlers. `Contexts` already rescues `BrowserError`/`TimeoutError` in `connect_worker` and the detach paths, which is this same hazard patched one call site at a time.

## The fix

Each callback is called with a rescue around it. The error goes to stderr, the other callbacks for that event still run, and the thread keeps dispatching:

```
Ferrum: Target.targetCreated callback raised Ferrum::TimeoutError: Timed out waiting for response...
  repro.rb:9:in 'block in <main>'
```

The snippet above then runs to completion: both later `create_page` calls succeed and the existing page still navigates.

## Verification

- New unit spec, `spec/unit/client/subscriber_spec.rb`: a raising callback doesn't stop the events that follow, and the error is reported. Both examples fail with `Timeout::Error` without the fix, since nothing is dispatched after the raise.
- Full suite: 616 examples, 0 failures.

Note this is the amplifier, not the trigger, for #470. The timeouts that set it off there look like the two races fixed in #602 (unlocked command-id minting and unserialized `websocket-driver` access), which also explains why `flatten: false` helped in that thread: flatten funnels every page's commands through one client and one socket, maximising both races. This change makes a single such timeout survivable instead of fatal to the whole run.
