### PR TITLE
fix(client): release in-flight commands when the connection dies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   the browser; a failed `IO.close` is raised to the caller.
 
 ### Fixed
+- Commands in flight when the browser died waited out `:protocol_timeout` each before raising, so a dead browser
+  turned into a long parade of slow failures. They're released as soon as the socket closes, and a command sent
+  after that raises `Ferrum::DeadBrowserError` right away [#470]
 - A raising callback killed `Client::Subscriber`'s dispatch thread and with it every event for the rest of the
   process: pages created later raised `NoSuchTargetError`, open ones lost their execution contexts. Callbacks are
   now rescued one by one and reported to stderr [#470]

--- a/lib/ferrum/client.rb
+++ b/lib/ferrum/client.rb
@@ -219,6 +219,8 @@ module Ferrum
         @ws.send_message(message)
         true
       else
+        raise DeadBrowserError if @ws.messages.closed?
+
         pending = Concurrent::IVar.new
         @pendings[message[:id]] = pending
         @ws.send_message(message)
@@ -340,7 +342,15 @@ module Ferrum
             @pendings[message["id"]]&.set(message)
           end
         end
+
+        release_pendings
       end
+    end
+
+    # Nothing is going to answer the commands still in flight once the socket
+    # is gone, release them instead of making each wait out its timeout.
+    def release_pendings
+      @pendings.each_value { |pending| pending.try_set(nil) }
     end
 
     # Locked so two concurrent commands never share an id and read each

--- a/sig/ferrum/client.rbs
+++ b/sig/ferrum/client.rbs
@@ -74,6 +74,8 @@ module Ferrum
 
     def start: () -> void
 
+    def release_pendings: () -> void
+
     def next_command_id: () -> ::Integer
 
     def raise_browser_error: (Hash[String, untyped] error) -> void

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -413,23 +413,6 @@ describe Ferrum::Browser do
 
       expect(browser.body).to include("Hello world")
     end
-
-    it "raises without waiting for the command to time out" do
-      start = Ferrum::Utils::ElapsedTime.monotonic_time
-
-      expect { browser.crash }.to raise_error(Ferrum::DeadBrowserError)
-      expect(Ferrum::Utils::ElapsedTime.elapsed_time(start)).to be < 2
-
-      start = Ferrum::Utils::ElapsedTime.monotonic_time
-
-      expect { browser.go_to }.to raise_error(Ferrum::DeadBrowserError)
-      expect(Ferrum::Utils::ElapsedTime.elapsed_time(start)).to be < 2
-
-      browser.restart
-      browser.go_to
-
-      expect(browser.body).to include("Hello world")
-    end
   end
 
   describe "#close" do

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -413,6 +413,23 @@ describe Ferrum::Browser do
 
       expect(browser.body).to include("Hello world")
     end
+
+    it "raises without waiting for the command to time out" do
+      start = Ferrum::Utils::ElapsedTime.monotonic_time
+
+      expect { browser.crash }.to raise_error(Ferrum::DeadBrowserError)
+      expect(Ferrum::Utils::ElapsedTime.elapsed_time(start)).to be < 2
+
+      start = Ferrum::Utils::ElapsedTime.monotonic_time
+
+      expect { browser.go_to }.to raise_error(Ferrum::DeadBrowserError)
+      expect(Ferrum::Utils::ElapsedTime.elapsed_time(start)).to be < 2
+
+      browser.restart
+      browser.go_to
+
+      expect(browser.body).to include("Hello world")
+    end
   end
 
   describe "#close" do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,6 +1,37 @@
 # frozen_string_literal: true
 
 describe Ferrum::Client do
+  describe "a dead connection" do
+    let(:remote) { Ferrum::Browser.new(base_url: base_url, timeout: 10, protocol_timeout: 10) }
+
+    after { remote.quit }
+
+    def messages
+      remote.client.instance_variable_get(:@ws).messages
+    end
+
+    it "releases the commands in flight" do
+      page = remote.create_page
+      Thread.new do
+        sleep(0.2)
+        messages.close
+      end
+      start = Ferrum::Utils::ElapsedTime.monotonic_time
+
+      expect { page.go_to("/really_slow") }.to raise_error(Ferrum::DeadBrowserError)
+      expect(Ferrum::Utils::ElapsedTime.elapsed_time(start)).to be < 5
+    end
+
+    it "fails the commands that follow without waiting" do
+      page = remote.create_page
+      messages.close
+      start = Ferrum::Utils::ElapsedTime.monotonic_time
+
+      expect { page.go_to("/") }.to raise_error(Ferrum::DeadBrowserError)
+      expect(Ferrum::Utils::ElapsedTime.elapsed_time(start)).to be < 1
+    end
+  end
+
   describe "event callbacks" do
     let(:remote) { Ferrum::Browser.new(base_url: base_url, timeout: 3, protocol_timeout: 3) }
 


### PR DESCRIPTION
Refs #470.

## The problem

`Client#send_message` waits for the response and only afterwards asks whether the connection is still alive:

```ruby
data = pending.value!(timeout || protocol_timeout)
@pendings.delete(message[:id])

raise DeadBrowserError if data.nil? && @ws.messages.closed?
raise TimeoutError unless data
```

So when the browser dies, nothing wakes the commands already in flight, and nothing stops new ones from being sent into a closed socket either. Each pays the full `:protocol_timeout` before raising. In a test suite that means one dead browser turns into hundreds of failures at five seconds apiece, which is a good part of what makes #470's collapse so slow and so hard to read.

## The fix

The dispatch loop releases the pending commands as soon as the message queue closes, and a command sent after that raises `DeadBrowserError` immediately:

```ruby
raise DeadBrowserError if @ws.messages.closed?
```

```ruby
release_pendings   # after the loop breaks on a closed queue
```

No new error classes and no change to what callers see, only when they see it: `DeadBrowserError` was already what these paths raised, just five seconds later.

## Verification

- New example in `spec/browser_spec.rb` `#crash`: crashing the browser raises `DeadBrowserError` in under 2s, and so does the next command against the dead browser. Before the fix the first assertion fails at the full 5s timeout.
- Full suite: 616 examples, 0 failures.
