### PR TITLE
fix(client): keep Ferrum's threads from taking the host process down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   the browser; a failed `IO.close` is raised to the caller.
 
 ### Fixed
+- An error in the client or websocket thread was re-raised in the main thread wherever it happened to be, or took
+  the process down with it, since `Utils::Thread.spawn` defaulted to `abort_on_exception: true` and neither thread
+  rescued. Ferrum's threads no longer abort, they report to stderr and mark the connection dead [#470]
 - Commands in flight when the browser died waited out `:protocol_timeout` each before raising, so a dead browser
   turned into a long parade of slow failures. They're released as soon as the socket closes, and a command sent
   after that raises `Ferrum::DeadBrowserError` right away [#470]

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -177,7 +177,7 @@ module Ferrum
         user_data_dir = @user_data_dir
         @pid = @user_data_dir = nil
 
-        Utils::Thread.spawn(abort_on_exception: false) do
+        Utils::Thread.spawn do
           Killer.kill(pid) if pid
           Killer.kill(xvfb_pid) if xvfb_pid
           Killer.remove_directory(user_data_dir) if user_data_dir

--- a/lib/ferrum/client.rb
+++ b/lib/ferrum/client.rb
@@ -342,7 +342,12 @@ module Ferrum
             @pendings[message["id"]]&.set(message)
           end
         end
-
+      rescue StandardError => e
+        # Nothing delivers responses once this thread is gone, so the connection
+        # is done for. Close it rather than leave every command hanging.
+        warn("Ferrum: dispatch stopped, #{e.class}: #{e.message}\n  #{e.backtrace&.first}")
+        @ws.messages.close
+      ensure
         release_pendings
       end
     end

--- a/lib/ferrum/client/subscriber.rb
+++ b/lib/ferrum/client/subscriber.rb
@@ -106,7 +106,7 @@ module Ferrum
       private
 
       def start
-        @regular_thread = Utils::Thread.spawn(abort_on_exception: false) do
+        @regular_thread = Utils::Thread.spawn do
           loop do
             message = @regular.pop
             break unless message
@@ -115,7 +115,7 @@ module Ferrum
           end
         end
 
-        @priority_thread = Utils::Thread.spawn(abort_on_exception: false) do
+        @priority_thread = Utils::Thread.spawn do
           loop do
             message = @priority.pop
             break unless message

--- a/lib/ferrum/client/web_socket.rb
+++ b/lib/ferrum/client/web_socket.rb
@@ -152,6 +152,10 @@ module Ferrum
             @driver_mutex.synchronize { @driver.parse(data) }
           end
         rescue EOFError, Errno::ECONNRESET, Errno::EPIPE, IOError # rubocop:disable Lint/ShadowedException
+          # The browser went away, nothing to report.
+        rescue StandardError => e
+          warn("Ferrum: websocket reader stopped, #{e.class}: #{e.message}\n  #{e.backtrace&.first}")
+        ensure
           @messages.close
         end
       end

--- a/lib/ferrum/utils/thread.rb
+++ b/lib/ferrum/utils/thread.rb
@@ -14,10 +14,12 @@ module Ferrum
       #
       # @param [Boolean] abort_on_exception
       #   Whether the thread aborts the process if it raises an unhandled exception.
+      #   Off by default: an exception in one of Ferrum's own threads reaches the
+      #   main thread wherever it happens to be, or kills the process outright.
       #
       # @return [Thread]
       #
-      def spawn(abort_on_exception: true)
+      def spawn(abort_on_exception: false)
         ::Thread.new(abort_on_exception) do |whether_abort_on_exception|
           ::Thread.current.abort_on_exception = whether_abort_on_exception
           ::Thread.current.report_on_exception = true if ::Thread.current.respond_to?(:report_on_exception=)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -37,6 +37,16 @@ describe Ferrum::Client do
       expect { page.go_to("/") }.to raise_error(Ferrum::DeadBrowserError)
       expect(Ferrum::Utils::ElapsedTime.elapsed_time(start)).to be < 1
     end
+
+    it "reports an unexpected reader error instead of raising in the main thread" do
+      page = remote.create_page
+      driver = remote.client.instance_variable_get(:@ws).instance_variable_get(:@driver)
+      allow(driver).to receive(:parse).and_raise(Errno::ETIMEDOUT)
+
+      expect do
+        expect { page.go_to("/") }.to raise_error(Ferrum::DeadBrowserError)
+      end.to output(/websocket reader stopped, Errno::ETIMEDOUT/).to_stderr
+    end
   end
 
   describe "event callbacks" do


### PR DESCRIPTION
Refs #470.

## The problem

`Utils::Thread.spawn` defaulted to `abort_on_exception: true`, and the two transport threads used that default. The client dispatch thread has no rescue at all, and the websocket reader rescues only `EOFError, ECONNRESET, EPIPE, IOError`. Anything else is re-raised in the main thread wherever it happens to be.

Forcing one on main, an error the reader doesn't expect:

```ruby
b = Ferrum::Browser.new
page = b.create_page
driver = b.client.instance_variable_get(:@ws).instance_variable_get(:@driver)
def driver.parse(_data) = raise(Errno::ETIMEDOUT)

page.go_to("data:text/html,<h1>hi</h1>")   # Errno::ETIMEDOUT, out of a navigation
```

In a suite that's a failure attributed to whatever call was unlucky enough to be running. In a server it's process death, with the caller's `ensure` never getting to `browser.quit`.

## The change

- `Utils::Thread.spawn` defaults to `abort_on_exception: false`. Every call site already passed `false` except these two, so the explicit arguments are gone and the intent lives in one place. The deliberate main-thread raise for JS errors is untouched: it uses `Thread.main.raise` directly.
- Both transport threads rescue and report to stderr, and the websocket reader closes `@messages` in an `ensure` rather than only on expected disconnects.
- Either thread dying now means the connection is dead, so callers get `Ferrum::DeadBrowserError` rather than an error from a place they never called.

The snippet above becomes:

```
Ferrum: websocket reader stopped, Errno::ETIMEDOUT: Operation timed out
  ...
Ferrum::DeadBrowserError
```

## Verification

- New example in `spec/client_spec.rb`: an unexpected error in the reader is reported and the next command raises `DeadBrowserError`. Without the fix the example fails with `expected Ferrum::DeadBrowserError, got #<Errno::ETIMEDOUT>`.
- Full suite: 616 examples, 0 failures.

Overlaps #630 slightly: there the pendings are released when the queue closes, so with both merged the `DeadBrowserError` here arrives immediately rather than after `:protocol_timeout`. Trivial conflict in `Client#start` if they land in the same window.
