### PR TITLE
change(options): stop tying :protocol_timeout to :timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   mobile device's viewport and touch support together. [#94]
 
 ### Changed
+- `:protocol_timeout` defaults to 30 seconds instead of following `:timeout`. Internal CDP calls resolve in
+  milliseconds, so the old default made `timeout: 1` shorten browser bookkeeping too and turned a loaded machine
+  into `Ferrum::TimeoutError` during page creation [#470]
 - `Ferrum::Page::Stream#stream` now closes the CDP stream handle (`IO.close`) once it's been fully read, so streams
   opened for `Ferrum::Browser#pdf` and `Ferrum::Page::Tracing#record` no longer keep their backing storage alive in
   the browser; a failed `IO.close` is raised to the caller.

--- a/docs/2-customization.md
+++ b/docs/2-customization.md
@@ -28,7 +28,12 @@ Ferrum::Browser.new(options)
     * `:slowmo` (Integer | Float) - Set a delay in seconds to wait before sending command.
       Useful companion of headless option, so that you have time to see changes.
     * `:timeout` (Numeric) - The number of seconds we'll wait for a response when
-      communicating with browser. Default is 5.
+      communicating with browser: navigations, JS evaluation, DOM queries,
+      dispatching input, etc. Default is 5.
+    * `:protocol_timeout` (Numeric) - The number of seconds we'll wait for an
+      internal CDP bookkeeping call to respond, e.g. `Target.createTarget`.
+      They normally resolve in milliseconds, so this only runs out when the
+      machine is heavily loaded. Default is 30.
     * `:js_errors` (Boolean) - When true, JavaScript errors get re-raised in Ruby.
     * `:pending_connection_errors` (Boolean) - Raise `PendingConnectionsError` when main frame is still waiting
       for slow responses and timeout is reached. Default is false.

--- a/lib/ferrum/browser.rb
+++ b/lib/ferrum/browser.rb
@@ -89,10 +89,12 @@ module Ferrum
     #   The number of seconds we'll wait for a response when communicating
     #   with the browser: navigations, JS evaluation, DOM queries, dispatching input, etc.
     #
-    # @option options [Numeric] :protocol_timeout (5)
+    # @option options [Numeric] :protocol_timeout (30)
     #   The number of seconds we'll wait for an individual internal CDP
     #   bookkeeping call to respond, e.g. `Target.createTarget`,
-    #   `Target.attachToTarget`. These normally resolve in milliseconds.
+    #   `Target.attachToTarget`. These normally resolve in milliseconds, the
+    #   budget is generous because exceeding it means the machine is loaded,
+    #   not that the browser is gone, that case is detected on its own.
     #
     # @option options [Boolean] :js_errors
     #   When true, JavaScript errors get re-raised in Ruby.

--- a/lib/ferrum/browser/options.rb
+++ b/lib/ferrum/browser/options.rb
@@ -14,7 +14,7 @@ module Ferrum
       WINDOW_SIZE = [1024, 768].freeze
       BASE_URL_SCHEMA = %w[http https].freeze
       DEFAULT_TIMEOUT = ENV.fetch("FERRUM_DEFAULT_TIMEOUT", 5).to_i
-      DEFAULT_PROTOCOL_TIMEOUT = ENV.fetch("FERRUM_PROTOCOL_TIMEOUT", DEFAULT_TIMEOUT).to_i
+      DEFAULT_PROTOCOL_TIMEOUT = ENV.fetch("FERRUM_PROTOCOL_TIMEOUT", 30).to_i
       PROCESS_TIMEOUT = ENV.fetch("FERRUM_PROCESS_TIMEOUT", 10).to_i
       DEBUG_MODE = !ENV.fetch("FERRUM_DEBUG", nil).nil?
 

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -63,6 +63,19 @@ describe Ferrum::Browser do
       browser&.quit
     end
 
+    it "supports :protocol_timeout argument" do
+      browser = Ferrum::Browser.new(base_url: base_url, timeout: 1)
+
+      expect(browser.timeout).to eq(1)
+      expect(browser.protocol_timeout).to eq(30)
+
+      browser.protocol_timeout = 2
+
+      expect(browser.protocol_timeout).to eq(2)
+    ensure
+      browser&.quit
+    end
+
     it "supports :process_timeout argument" do
       path = "#{PROJECT_ROOT}/spec/support/no_chrome"
 


### PR DESCRIPTION
Refs #470.

## The problem

```ruby
DEFAULT_PROTOCOL_TIMEOUT = ENV.fetch("FERRUM_PROTOCOL_TIMEOUT", DEFAULT_TIMEOUT).to_i
```

`:timeout` is a user-facing knob: how long to wait for a navigation, an evaluation, a DOM query. People set it low on purpose. `:protocol_timeout` is a different thing, the budget for internal CDP bookkeeping, `Target.createTarget`, `Target.attachToTarget`, `Page.enable`, calls that resolve in milliseconds on a healthy machine.

Tying the second to the first means `Ferrum::Browser.new(timeout: 1)` also gives target creation one second, and 5 by default. On a loaded CI box that is not enough, and what comes out is a `Ferrum::TimeoutError` while creating a page, which is precisely the shape of #470: `Page.enable` never answering on a busy runner, then the whole run unravelling.

## The change

`:protocol_timeout` defaults to 30 seconds, independent of `:timeout`, still settable per browser and through `FERRUM_PROTOCOL_TIMEOUT`. Page-level waits are unaffected, `Page#command` passes `:timeout` as before.

Generous is the right default here: running out of this budget means the machine is struggling, not that the browser is gone. A browser that has actually died is detected by the socket closing, not by this timer.

## Verification

- New example in `spec/browser_spec.rb`: `timeout: 1` no longer drags `protocol_timeout` down with it, and the setter still works. Fails before the change, `protocol_timeout` is 1 there.
- Full suite: 616 examples, 0 failures.
- `:protocol_timeout` is now documented in `docs/2-customization.md` next to `:timeout`, it was missing.

Best merged after #630, which is what makes a dead browser raise immediately rather than after this timeout. On its own this change makes that detection slower, 30s instead of 5s, until #630 lands.
